### PR TITLE
Docs tweaks

### DIFF
--- a/src/Data/MinLen.hs
+++ b/src/Data/MinLen.hs
@@ -229,8 +229,8 @@ last = lastEx . unMinLen
 -- ==== __Examples__
 -- 
 -- > > let xs = toMinLen [1,2,3] :: Maybe (MinLen (Succ Zero) [Int])
--- > > fmap initML xs
--- > Just (MinLen {unMinLen = [1,2]})
+-- > > fmap tailML xs
+-- > Just (MinLen {unMinLen = [2,3]})
 tailML :: IsSequence seq => MinLen (Succ nat) seq -> MinLen nat seq
 tailML = MinLen . tailEx . unMinLen
 

--- a/src/Data/MinLen.hs
+++ b/src/Data/MinLen.hs
@@ -95,8 +95,8 @@ type instance MaxNat (Succ x) (Succ y) = Succ (MaxNat x y)
 --
 -- > head :: MonoTraversable mono => MinLen (Succ nat) mono -> Element mono
 --
--- The length is also a phantom type, i.e. it is only used
--- on the left hand side of the type and doesn't exist at runtime.
+-- The length is also a <https://wiki.haskell.org/Phantom_type phantom type>,
+-- i.e. it is only used on the left hand side of the type and doesn't exist at runtime.
 -- Notice how @Succ Zero@ isn't included in the printed output:
 --
 -- > > toMinLen [1,2,3] :: Maybe (MinLen (Succ Zero) [Int])


### PR DESCRIPTION
* Fixes tailML documentation (it was previously using initML by mistake). Thanks @gregwebs 
* Adds a link to the haskell wiki page on phantom types