### PR TITLE
Fill in missing Mono* instances

### DIFF
--- a/src/Data/MinLen.hs
+++ b/src/Data/MinLen.hs
@@ -165,6 +165,7 @@ newtype MinLen nat mono =
 type instance Element (MinLen nat mono) = Element mono
 deriving instance MonoFunctor mono => MonoFunctor (MinLen nat mono)
 deriving instance MonoFoldable mono => MonoFoldable (MinLen nat mono)
+deriving instance MonoFoldableEq mono => MonoFoldableEq (MinLen nat mono)
 deriving instance MonoFoldableOrd mono => MonoFoldableOrd (MinLen nat mono)
 instance MonoTraversable mono => MonoTraversable (MinLen nat mono) where
     otraverse f (MinLen x) = fmap MinLen (otraverse f x)


### PR DESCRIPTION
I noticed that there are several `Element` instances that don't have `MonoFoldable`, `MonoTraversable`, `MonoPointed`, etc. instances, so I went through and implemented them. For `MonoPointed`, I manually defined some instances to obtain less restrictive contexts (e.g., `Applicative` instead of `Monad`).