### PR TITLE
MonoComonad typeclass, if desired

### DIFF
--- a/mono-traversable.cabal
+++ b/mono-traversable.cabal
@@ -37,7 +37,6 @@ library
                      , vector-algorithms >= 0.6
                      , dlist >= 0.6 && < 1.0
                      , dlist-instances == 0.1.*
-                     , comonad
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/mono-traversable.cabal
+++ b/mono-traversable.cabal
@@ -37,6 +37,7 @@ library
                      , vector-algorithms >= 0.6
                      , dlist >= 0.6 && < 1.0
                      , dlist-instances == 0.1.*
+                     , comonad
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
As discussed in http://www.reddit.com/r/haskell/comments/2nmf5l/image_processing_with_comonads/cmf8o9v :)

Granted I'm not really sure if it's the best idea to really put another typeclass that doesn't have too many usages in the wild.  I'm planning on releasing a library using `MonoComonad`, but one library in the future doesn't quite fully justify it to me...but take with it what you want/need :)

The way the typeclass fits into the `mono-traversable` picture, I feel like it would make sense to split this into a `MonoExtractable` typeclass with only `extract :: mono -> Element mono`, because on its own it has some sort of meaning.  It's sort of weird to formulate a picture of `Comonad` using only monomorphic terms, but I tried my best to capture what a monomorphic `extend` might mean, and also the associated law(s).