### PR TITLE
Remove INLINE pragma without method binding

### DIFF
--- a/src/Data/MonoTraversable.hs
+++ b/src/Data/MonoTraversable.hs
@@ -599,7 +599,6 @@ instance MonoFoldable (Vector a) where
     unsafeLast = V.unsafeLast
     maximumByEx = V.maximumBy
     minimumByEx = V.minimumBy
-    {-# INLINE ofoldMap #-}
     {-# INLINE ofoldr #-}
     {-# INLINE ofoldl' #-}
     {-# INLINE otoList #-}


### PR DESCRIPTION
There is an `{-# INLINE ofoldMap #-}` pragma without a method binding in the `MonoFoldable (Vector a)` instance that was giving the warning `makeCorePair: arity missing $cofoldMap_aduS`. After [Trac #5001](https://ghc.haskell.org/trac/ghc/ticket/5001#comment:25) was fixed, however, this would result in an error. To avoid this, I simply removed the pragma, as it doesn't do anything.