### PR TITLE
fix law stated for GrowingAppend class

### DIFF
--- a/src/Data/GrowingAppend.hs
+++ b/src/Data/GrowingAppend.hs
@@ -22,7 +22,7 @@ import qualified Data.IntMap as IntMap
 import qualified Data.DList as DList
 import Data.DList.Instances ()
 
--- | olength (x <> y) >= olength x + olength y
+-- | olength (x <> y) >= max (olength x) (olength y)
 class (Semigroup mono, MonoFoldable mono) => GrowingAppend mono
 
 instance GrowingAppend (Seq.Seq a)


### PR DESCRIPTION
The instances only satisfy a weaker form of the stated law, and we only rely on the fact
that `olength (a <> b) >= max (olength a) (olength b)`.

Fixes #91