### PR TITLE
Generate the same random numbers on each run in the benchmarks

### DIFF
--- a/bench/sorting.hs
+++ b/bench/sorting.hs
@@ -18,7 +18,8 @@ main = do
 
 mkGroup :: Int -> IO Benchmark
 mkGroup size = do
-    inputV <- MWC.withSystemRandom . MWC.asGenST $ flip MWC.uniformVector size
+    gen <- MWC.create
+    inputV <- MWC.uniformVector gen size
     let inputL = otoList (inputV :: V.Vector Int)
         inputVU = fromList inputL :: U.Vector Int
     return $ bgroup (show size)


### PR DESCRIPTION
I've noticed that the numbers that `criterion` reports for this benchmark can vary quite a bit from run to run—sometimes a difference of about 20%. The culprit seems to be the list that gets randomly generated once and used in every iteration. I suspect the sorting algorithms perform much better depending on how well sorted the generated list is, which would account for the differing benchmark times.

My solution is to use the `create` function from `mwc-random`, which uses a fixed seed, instead of of `withSystemRandom`. This way, the same numbers will be generated for every run of the benchmarks.