### PR TITLE
Fix foldl1 not being "a strict left fold" as advertised.

### DIFF
--- a/conduit-combinators/Data/Conduit/Combinators.hs
+++ b/conduit-combinators/Data/Conduit/Combinators.hs
@@ -717,7 +717,7 @@ foldl1, foldl1C :: Monad m => (a -> a -> a) -> Consumer a m (Maybe a)
 foldl1C f =
     await >>= maybe (return Nothing) loop
   where
-    loop prev = await >>= maybe (return $ Just prev) (loop . f prev)
+    loop !prev = await >>= maybe (return $ Just prev) (loop . f prev)
 STREAMING(foldl1, foldl1C, foldl1S, f)
 
 -- | A strict left fold on a chunked stream, with no starting value.


### PR DESCRIPTION
An example of this is `Combinators.minimum`, which until
now would thunk up `min(_, min(...))`, instead of demanding
each `min` result, leading to non-constant memory usage.

I haven't checked if other functions need a similar change.