### PR TITLE
Update base bound to reflect supported compilers

### DIFF
--- a/mono-traversable/mono-traversable.cabal
+++ b/mono-traversable/mono-traversable.cabal
@@ -20,7 +20,7 @@ library
                        Data.Containers
                        Data.Sequences
                        Data.NonNull
-  build-depends:       base >= 4.5 && < 5
+  build-depends:       base >= 4.7 && < 5
                      , containers >= 0.4
                      , unordered-containers >=0.2
                      , hashable


### PR DESCRIPTION
Does not install for GHC < 7.8