### PR TITLE
Less generalized I/O

### DIFF
--- a/classy-prelude-conduit/classy-prelude-conduit.cabal
+++ b/classy-prelude-conduit/classy-prelude-conduit.cabal
@@ -1,5 +1,5 @@
 name:                classy-prelude-conduit
-version:             1.0.2
+version:             1.2.0
 synopsis:            classy-prelude together with conduit functions
 description:         classy-prelude together with conduit functions
 homepage:            https://github.com/snoyberg/mono-traversable
@@ -16,7 +16,7 @@ library
   exposed-modules:     ClassyPrelude.Conduit
   build-depends:       base                          >= 4          && < 5
                      , conduit                       >= 1.0        && < 1.3
-                     , classy-prelude                >= 1.0.2      && < 1.0.3
+                     , classy-prelude                >= 1.2.0      && < 1.2.1
                      , transformers
                      , monad-control
                      , resourcet

--- a/classy-prelude-yesod/classy-prelude-yesod.cabal
+++ b/classy-prelude-yesod/classy-prelude-yesod.cabal
@@ -1,5 +1,5 @@
 name:                classy-prelude-yesod
-version:             1.1.0
+version:             1.2.0
 synopsis:            Provide a classy prelude including common Yesod functionality.
 description:         This is an extension of classy-prelude-conduit, adding in commonly used functions and data types from Yesod.
 homepage:            https://github.com/snoyberg/mono-traversable
@@ -15,8 +15,8 @@ extra-source-files:  README.md ChangeLog.md
 library
   exposed-modules:     ClassyPrelude.Yesod
   build-depends:       base >= 4 && < 5
-                     , classy-prelude >= 1.0.2 && < 1.0.3
-                     , classy-prelude-conduit >= 1.0.2 && < 1.0.3
+                     , classy-prelude >= 1.2.0 && < 1.2.1
+                     , classy-prelude-conduit >= 1.2.0 && < 1.2.1
                      , yesod >= 1.2
                      , yesod-newsfeed
                      , yesod-static

--- a/classy-prelude/ChangeLog.md
+++ b/classy-prelude/ChangeLog.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+* Don't generalize I/O functions to `IOData`, instead specialize to
+  `ByteString`. See:
+  http://www.snoyman.com/blog/2016/12/beware-of-readfile#real-world-failures
+
 ## 1.0.2
 
 * Export `parseTimeM` for `time >= 1.5`

--- a/classy-prelude/classy-prelude.cabal
+++ b/classy-prelude/classy-prelude.cabal
@@ -1,5 +1,5 @@
 name:                classy-prelude
-version:             1.0.2
+version:             1.2.0
 synopsis:            A typeclass-based Prelude.
 description:         Modern best practices without name collisions. No partial functions are exposed, but modern data structures are, without requiring import lists. Qualified modules also are not needed: instead operations are based on type-classes from the mono-traversable package.
 

--- a/conduit-combinators/ChangeLog.md
+++ b/conduit-combinators/ChangeLog.md
@@ -1,3 +1,9 @@
+# 1.1.0
+
+* Don't generalize I/O functions to `IOData`, instead specialize to
+  `ByteString`. See:
+  http://www.snoyman.com/blog/2016/12/beware-of-readfile#real-world-failures
+
 # 1.0.8.3
 
 * Fix version bounds for chunked-data/mono-traversable combos

--- a/conduit-combinators/Data/Conduit/Combinators/Stream.hs
+++ b/conduit-combinators/Data/Conduit/Combinators/Stream.hs
@@ -12,7 +12,6 @@ module Data.Conduit.Combinators.Stream
   ( yieldManyS
   , repeatMS
   , repeatWhileMS
-  , sourceHandleS
   , foldl1S
   , allS
   , anyS
@@ -43,12 +42,10 @@ module Data.Conduit.Combinators.Stream
 
 import           Control.Monad (liftM)
 import           Control.Monad.Base (MonadBase (liftBase))
-import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Primitive (PrimMonad)
 import           Data.Builder
 import           Data.Conduit.Internal.Fusion
 import           Data.Conduit.Internal.List.Stream (foldS)
-import           Data.IOData
 import           Data.Maybe (isNothing, isJust)
 import           Data.MonoTraversable
 #if ! MIN_VERSION_base(4,8,0)
@@ -59,7 +56,6 @@ import qualified Data.Sequences as Seq
 import qualified Data.Vector.Generic as V
 import qualified Data.Vector.Generic.Mutable as VM
 import           Prelude
-import           System.IO (Handle)
 
 #if MIN_VERSION_mono_traversable(1,0,0)
 import           Data.Sequences (LazySequence (..))
@@ -101,17 +97,6 @@ repeatWhileMS m f _ =
             then Emit () x
             else Stop ()
 {-# INLINE repeatWhileMS #-}
-
-sourceHandleS :: (MonadIO m, MonoFoldable a, IOData a) => Handle -> StreamProducer m a
-sourceHandleS h _ =
-    Stream step (return ())
-  where
-    step () = do
-        x <- liftIO (hGetChunk h)
-        return $ if onull x
-            then Stop ()
-            else Emit () x
-{-# INLINE sourceHandleS #-}
 
 foldl1S :: Monad m
         => (a -> a -> a)

--- a/conduit-combinators/Data/Conduit/Combinators/Unqualified.hs
+++ b/conduit-combinators/Data/Conduit/Combinators/Unqualified.hs
@@ -24,10 +24,10 @@ module Data.Conduit.Combinators.Unqualified
     , replicateMC
 
       -- *** I\/O
-    , sourceFile
+    , CC.sourceFile
     , CC.sourceFileBS
-    , sourceHandle
-    , sourceIOHandle
+    , CC.sourceHandle
+    , CC.sourceIOHandle
     , stdinC
 
       -- *** Random numbers
@@ -109,10 +109,10 @@ module Data.Conduit.Combinators.Unqualified
     , foldMapMCE
 
       -- *** I\/O
-    , sinkFile
+    , CC.sinkFile
     , CC.sinkFileBS
-    , sinkHandle
-    , sinkIOHandle
+    , CC.sinkHandle
+    , CC.sinkIOHandle
     , printC
     , stdoutC
     , stderrC
@@ -187,19 +187,11 @@ import qualified Data.Conduit.Combinators as CC
 import Data.Builder
 import qualified Data.NonNull as NonNull
 import qualified Data.Traversable
-#if ! MIN_VERSION_base(4,8,0)
-import           Control.Applicative         ((<$>))
-#else
-import           Prelude                     ((<$>))
-#endif
 import           Control.Monad.Base          (MonadBase (..))
 import           Control.Monad.IO.Class      (MonadIO (..))
 import           Control.Monad.Primitive     (PrimMonad, PrimState)
 import           Control.Monad.Trans.Resource (MonadResource, MonadThrow)
 import           Data.Conduit
-import qualified Data.Conduit.List           as CL
-import           Data.IOData
-import           Data.Maybe                  (fromMaybe)
 import           Data.Monoid                 (Monoid (..))
 import           Data.MonoTraversable
 import qualified Data.Sequences              as Seq
@@ -209,8 +201,6 @@ import           Prelude                     (Bool (..), Eq (..), Int,
                                               Ord (..), Functor (..), Either (..),
                                               Enum, Show, Char, FilePath)
 import Data.Word (Word8)
-import qualified Prelude
-import           System.IO                   (Handle)
 import qualified System.IO                   as SIO
 import Data.ByteString (ByteString)
 import Data.Text (Text)
@@ -324,39 +314,10 @@ replicateMC :: Monad m
 replicateMC = CC.replicateM
 {-# INLINE replicateMC #-}
 
--- | Read all data from the given file.
---
--- This function automatically opens and closes the file handle, and ensures
--- exception safety via @MonadResource. It works for all instances of @IOData@,
--- including @ByteString@ and @Text@.
---
--- Since 1.0.0
-sourceFile :: (MonadResource m, IOData a, MonoFoldable a) => FilePath -> Producer m a
-sourceFile = CC.sourceFile
-{-# INLINE sourceFile #-}
-
--- | Read all data from the given @Handle@.
---
--- Does not close the @Handle@ at any point.
---
--- Since 1.0.0
-sourceHandle :: (MonadIO m, IOData a, MonoFoldable a) => Handle -> Producer m a
-sourceHandle = CC.sourceHandle
-{-# INLINE sourceHandle #-}
-
--- | Open a @Handle@ using the given function and stream data from it.
---
--- Automatically closes the file at completion.
---
--- Since 1.0.0
-sourceIOHandle :: (MonadResource m, IOData a, MonoFoldable a) => SIO.IO Handle -> Producer m a
-sourceIOHandle = CC.sourceIOHandle
-{-# INLINE sourceIOHandle #-}
-
 -- | @sourceHandle@ applied to @stdin@.
 --
 -- Since 1.0.0
-stdinC :: (MonadIO m, IOData a, MonoFoldable a) => Producer m a
+stdinC :: MonadIO m => Producer m ByteString
 stdinC = CC.stdin
 {-# INLINE stdinC #-}
 
@@ -1007,35 +968,6 @@ foldMapMCE :: (Monad m, MonoFoldable mono, Monoid w)
 foldMapMCE = CC.foldMapME
 {-# INLINE foldMapMCE #-}
 
--- | Write all data to the given file.
---
--- This function automatically opens and closes the file handle, and ensures
--- exception safety via @MonadResource. It works for all instances of @IOData@,
--- including @ByteString@ and @Text@.
---
--- Since 1.0.0
-sinkFile :: (MonadResource m, IOData a) => FilePath -> Consumer a m ()
-sinkFile = CC.sinkFile
-{-# INLINE sinkFile #-}
-
--- | Write all data to the given @Handle@.
---
--- Does not close the @Handle@ at any point.
---
--- Since 1.0.0
-sinkHandle :: (MonadIO m, IOData a) => Handle -> Consumer a m ()
-sinkHandle = CC.sinkHandle
-{-# INLINE sinkHandle #-}
-
--- | Open a @Handle@ using the given function and stream data to it.
---
--- Automatically closes the file at completion.
---
--- Since 1.0.0
-sinkIOHandle :: (MonadResource m, IOData a) => SIO.IO Handle -> Consumer a m ()
-sinkIOHandle = CC.sinkIOHandle
-{-# INLINE sinkIOHandle #-}
-
 -- | Print all incoming values to stdout.
 --
 -- Since 1.0.0
@@ -1046,14 +978,14 @@ printC = CC.print
 -- | @sinkHandle@ applied to @stdout@.
 --
 -- Since 1.0.0
-stdoutC :: (MonadIO m, IOData a) => Consumer a m ()
+stdoutC :: MonadIO m => Consumer ByteString m ()
 stdoutC = CC.stdout
 {-# INLINE stdoutC #-}
 
 -- | @sinkHandle@ applied to @stderr@.
 --
 -- Since 1.0.0
-stderrC :: (MonadIO m, IOData a) => Consumer a m ()
+stderrC :: MonadIO m => Consumer ByteString m ()
 stderrC = CC.stderr
 {-# INLINE stderrC #-}
 

--- a/conduit-combinators/conduit-combinators.cabal
+++ b/conduit-combinators/conduit-combinators.cabal
@@ -1,5 +1,5 @@
 name:                conduit-combinators
-version:             1.0.8.3
+version:             1.1.0
 synopsis:            Commonly used conduit functions, for both chunked and unchunked data
 description:         Provides a replacement for Data.Conduit.List, as well as a convenient Conduit module.
 homepage:            https://github.com/snoyberg/mono-traversable

--- a/conduit-combinators/test/StreamSpec.hs
+++ b/conduit-combinators/test/StreamSpec.hs
@@ -42,14 +42,6 @@ import           Test.QuickCheck
 
 spec :: Spec
 spec = do
-    it "sourceHandleS works" $ do
-        let contents = Prelude.concat $ Prelude.replicate 10000 $ "this is some content\n"
-            fp = "tmp"
-        IO.writeFile fp contents
-        (res, ()) <- IO.withBinaryFile "tmp" IO.ReadMode $ \h ->
-            evalStream $ sourceHandleS h emptyStream
-        (TL.concat res) `shouldBe` TL.pack contents
-        removeFile "tmp"
     describe "Comparing list function to" $ do
         qit "yieldMany" $
             \(mono :: Seq Int) ->


### PR DESCRIPTION
Don't use IOData in conduit-combinators and classy-prelude, instead specializing to ByteString, thereby avoiding issues of:

* Implicit, incorrect character encodings
* Lazy I/O
* Inefficient data representation

See: http://www.snoyman.com/blog/2016/12/beware-of-readfile

Feel free to vote on this by clicking on the thumbs-up or thumbs-down. If you're opposed, please leave a comment explaining why.