### PR TITLE
Uses of tracing functions leave warnings

### DIFF
--- a/classy-prelude-conduit/classy-prelude-conduit.cabal
+++ b/classy-prelude-conduit/classy-prelude-conduit.cabal
@@ -1,5 +1,5 @@
 name:                classy-prelude-conduit
-version:             1.2.0
+version:             1.3.0
 synopsis:            classy-prelude together with conduit functions
 description:         classy-prelude together with conduit functions
 homepage:            https://github.com/snoyberg/mono-traversable
@@ -16,7 +16,7 @@ library
   exposed-modules:     ClassyPrelude.Conduit
   build-depends:       base                          >= 4          && < 5
                      , conduit                       >= 1.0        && < 1.3
-                     , classy-prelude                >= 1.2.0      && < 1.2.1
+                     , classy-prelude                >= 1.3.0      && < 1.3.1
                      , transformers
                      , monad-control
                      , resourcet

--- a/classy-prelude-yesod/classy-prelude-yesod.cabal
+++ b/classy-prelude-yesod/classy-prelude-yesod.cabal
@@ -1,5 +1,5 @@
 name:                classy-prelude-yesod
-version:             1.2.0
+version:             1.3.0
 synopsis:            Provide a classy prelude including common Yesod functionality.
 description:         This is an extension of classy-prelude-conduit, adding in commonly used functions and data types from Yesod.
 homepage:            https://github.com/snoyberg/mono-traversable
@@ -15,8 +15,8 @@ extra-source-files:  README.md ChangeLog.md
 library
   exposed-modules:     ClassyPrelude.Yesod
   build-depends:       base >= 4 && < 5
-                     , classy-prelude >= 1.2.0 && < 1.2.1
-                     , classy-prelude-conduit >= 1.2.0 && < 1.2.1
+                     , classy-prelude >= 1.3.0 && < 1.3.1
+                     , classy-prelude-conduit >= 1.3.0 && < 1.3.1
                      , yesod >= 1.2
                      , yesod-newsfeed
                      , yesod-static

--- a/classy-prelude/ChangeLog.md
+++ b/classy-prelude/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* Tracing functions leave warnings when used
+
 ## 1.2.0.1
 
 * Use `HasCallStack` in `undefined`

--- a/classy-prelude/ClassyPrelude.hs
+++ b/classy-prelude/ClassyPrelude.hs
@@ -220,7 +220,7 @@ import Data.Vector.Storable (unsafeToForeignPtr, unsafeFromForeignPtr)
 
 import System.IO (Handle, stdin, stdout, stderr, hClose)
 
-import Debug.Trace (trace, traceShow)
+import qualified Debug.Trace as Trace
 import Data.Semigroup (Semigroup (..), WrappedMonoid (..))
 import Prelude (Show (..))
 import Data.Time
@@ -382,27 +382,42 @@ undefined :: a
 undefined = error "ClassyPrelude.undefined"
 {-# DEPRECATED undefined "It is highly recommended that you either avoid partial functions or provide meaningful error messages" #-}
 
+-- | We define our own 'trace' (and also its variants) which provides a warning
+-- when used. So that tracing is available during development, but the compiler
+-- reminds you to not leave them in the code for production.
+{-# WARNING trace "Leaving traces in the code" #-}
+trace :: String -> a -> a
+trace = Trace.trace
+
+{-# WARNING traceShow "Leaving traces in the code" #-}
+traceShow :: Show a => a -> b -> b
+traceShow = Trace.traceShow
+
 -- |
 --
 -- Since 0.5.9
+{-# WARNING traceId "Leaving traces in the code" #-}
 traceId :: String -> String
-traceId a = trace a a
+traceId a = Trace.trace a a
 
 -- |
 --
 -- Since 0.5.9
+{-# WARNING traceM "Leaving traces in the code" #-}
 traceM :: (Monad m) => String -> m ()
-traceM string = trace string $ return ()
+traceM string = Trace.trace string $ return ()
 
 -- |
 --
 -- Since 0.5.9
+{-# WARNING traceShowId "Leaving traces in the code" #-}
 traceShowId :: (Show a) => a -> a
-traceShowId a = trace (show a) a
+traceShowId a = Trace.trace (show a) a
 
 -- |
 --
 -- Since 0.5.9
+{-# WARNING traceShowM "Leaving traces in the code" #-}
 traceShowM :: (Show a, Monad m) => a -> m ()
 traceShowM = traceM . show
 

--- a/classy-prelude/classy-prelude.cabal
+++ b/classy-prelude/classy-prelude.cabal
@@ -1,5 +1,5 @@
 name:                classy-prelude
-version:             1.2.0.1
+version:             1.3.0
 synopsis:            A typeclass-based Prelude.
 description:         Modern best practices without name collisions. No partial functions are exposed, but modern data structures are, without requiring import lists. Qualified modules also are not needed: instead operations are based on type-classes from the mono-traversable package.
 


### PR DESCRIPTION
This way you can use traces for debugging but have warnings to help you remember to remove them and not leave stale traces in your code.