### PR TITLE
add dropEnd to IsSequence and add Text implementation

### DIFF
--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.0.4.0
+
+* Add `dropEnd` function to the `IsSequence` class, and a specialized implementation for `Text`
+
 ## 1.0.3.0
 
 * Add `ensurePrefix` and `ensureSuffix` functions [#141](https://github.com/snoyberg/mono-traversable/pull/141)

--- a/mono-traversable/mono-traversable.cabal
+++ b/mono-traversable/mono-traversable.cabal
@@ -1,5 +1,5 @@
 name:                mono-traversable
-version:             1.0.3.0
+version:             1.0.4.0
 synopsis:            Type classes for mapping, folding, and traversing monomorphic containers
 description:         Monomorphic variants of the Functor, Foldable, and Traversable typeclasses. If you understand Haskell's basic typeclasses, you understand mono-traversable. In addition to what you are used to, it adds on an IsSequence typeclass and has code for marking data structures as non-empty.
 homepage:            https://github.com/snoyberg/mono-traversable

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -277,6 +277,8 @@ class (Monoid seq, MonoTraversable seq, SemiSequence seq, MonoPointed seq) => Is
     -- > 'dropEnd' 4 ('fromList' [1,2,3,4,5,6] :: 'Vector' 'Int')
     -- fromList [1,2]
     -- @
+    --
+    -- @since 1.0.4.0
     dropEnd :: Index seq -> seq -> seq
     dropEnd i s = fst $ splitAt (lengthIndex s - i) s
 

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -269,6 +269,17 @@ class (Monoid seq, MonoTraversable seq, SemiSequence seq, MonoPointed seq) => Is
     unsafeDrop :: Index seq -> seq -> seq
     unsafeDrop = drop
 
+    -- | Same as 'drop' but drops from the end of the sequence instead.
+    --
+    -- @
+    -- > 'dropEnd' 3 "abcdefg"
+    -- "abcd"
+    -- > 'dropEnd' 4 ('fromList' [1,2,3,4,5,6] :: 'Vector' 'Int')
+    -- fromList [1,2]
+    -- @
+    dropEnd :: Index seq -> seq -> seq
+    dropEnd i s = fst $ splitAt (lengthIndex s - i) s
+
     -- | 'partition' takes a predicate and a sequence and returns the pair of
     -- sequences of elements which do and do not satisfy the predicate.
     --
@@ -724,6 +735,7 @@ instance IsSequence T.Text where
     splitAt = T.splitAt
     take = T.take
     drop = T.drop
+    dropEnd = T.dropEnd
     partition = T.partition
     uncons = T.uncons
     unsnoc t


### PR DESCRIPTION
Here's an implementation of `dropEnd`. Of the `IsSequence` instances defined in `Data.Sequence`, only strict `Text` as I know of has an implementation of `dropEnd`. However there is an issue out to do this for `Data.ByteString`, and presumably other length-strict sequence types as well (`Seq`, `Vector`, etc), so if/when these libraries have them then the default could be overridden.