### PR TITLE
Add chunksOfE and chunksOfExactlyE

### DIFF
--- a/conduit-combinators/ChangeLog.md
+++ b/conduit-combinators/ChangeLog.md
@@ -1,3 +1,7 @@
+# 1.1.2
+
+* Add `chunksOfE` and `chunksOfExactlyE` combinators
+
 # 1.1.1
 
 * Add `asum` combinator

--- a/conduit-combinators/Data/Conduit/Combinators/Unqualified.hs
+++ b/conduit-combinators/Data/Conduit/Combinators/Unqualified.hs
@@ -141,6 +141,8 @@ module Data.Conduit.Combinators.Unqualified
     , concatMapAccumC
     , intersperseC
     , slidingWindowC
+    , chunksOfCE
+    , chunksOfExactlyCE
 
       -- **** Binary base encoding
     , encodeBase64C
@@ -1202,6 +1204,27 @@ intersperseC = CC.intersperse
 slidingWindowC :: (Monad m, Seq.IsSequence seq, Element seq ~ a) => Int -> Conduit a m seq
 slidingWindowC = CC.slidingWindow
 {-# INLINE slidingWindowC #-}
+
+
+-- | Split input into chunk of size 'chunkSize'
+--
+-- The last element may be smaller than the 'chunkSize' (see also
+-- 'chunksOfExactlyE' which will not yield this last element)
+--
+-- @since 1.1.2
+chunksOfCE :: (Monad m, Seq.IsSequence seq) => Seq.Index seq -> Conduit seq m seq
+chunksOfCE = CC.chunksOfE
+{-# INLINE chunksOfCE #-}
+
+-- | Split input into chunk of size 'chunkSize'
+--
+-- If the input does not split into chunks exactly, the remainder will be
+-- leftover (see also 'chunksOfE')
+--
+-- @since 1.1.2
+chunksOfExactlyCE :: (Monad m, Seq.IsSequence seq) => Seq.Index seq -> Conduit seq m seq
+chunksOfExactlyCE = CC.chunksOfExactlyE
+{-# INLINE chunksOfExactlyCE #-}
 
 -- | Apply base64-encoding to the stream.
 --

--- a/conduit-combinators/conduit-combinators.cabal
+++ b/conduit-combinators/conduit-combinators.cabal
@@ -1,5 +1,5 @@
 name:                conduit-combinators
-version:             1.1.1
+version:             1.1.2
 synopsis:            Commonly used conduit functions, for both chunked and unchunked data
 description:         Provides a replacement for Data.Conduit.List, as well as a convenient Conduit module.
 homepage:            https://github.com/snoyberg/mono-traversable


### PR DESCRIPTION
chunksOfE and chunksOfExactlyE break the input sequences into chunks of
a given size. If the input does not break into chunks of the given size,
then 'chunksOfE' will yield a last chunk that is not of the requested
size, while 'chunksOfExactlyE' will consider it a leftover element.

This was discussed as issue #142 