### PR TITLE
Add dropPrefix and dropSuffix functions

### DIFF
--- a/classy-prelude/test/main.hs
+++ b/classy-prelude/test/main.hs
@@ -187,19 +187,25 @@ chunkProps dummy = do
     prop "fromChunks . return . concat . toChunks == id" $ \a ->
         fromChunks [concat $ toChunks (a `asTypeOf` dummy)] == a
 
-stripSuffixProps :: ( Eq c
-                    , Show c
-                    , Arbitrary c
-                    , IsSequence c
-                    , Eq (Element c)
-                    )
-                 => c
-                 -> Spec
-stripSuffixProps dummy = do
+suffixProps :: ( Eq c
+               , Show c
+               , Arbitrary c
+               , IsSequence c
+               , Eq (Element c)
+               )
+            => c
+            -> Spec
+suffixProps dummy = do
+    prop "y `isSuffixOf` (x ++ y)" $ \x y ->
+        (y `asTypeOf` dummy) `isSuffixOf` (x ++ y)
     prop "stripSuffix y (x ++ y) == Just x" $ \x y ->
         stripSuffix y (x ++ y) == Just (x `asTypeOf` dummy)
     prop "isJust (stripSuffix x y) == isSuffixOf x y" $ \x y ->
         isJust (stripSuffix x y) == isSuffixOf x (y `asTypeOf` dummy)
+    prop "dropSuffix y (x ++ y) == x" $ \x y ->
+        dropSuffix y (x ++ y) == (x `asTypeOf` dummy)
+    prop "dropSuffix x y == y || x `isSuffixOf` y" $ \x y ->
+        dropSuffix x y == y || x `isSuffixOf` (y `asTypeOf` dummy)
 
 replicateMProps :: ( Eq a
                    , Show (Index a)
@@ -252,6 +258,10 @@ prefixProps dummy = do
         stripPrefix x (x ++ y) == Just (y `asTypeOf` dummy)
     prop "stripPrefix x y == Nothing || x `isPrefixOf` y" $ \x y ->
         stripPrefix x y == Nothing || x `isPrefixOf` (y `asTypeOf` dummy)
+    prop "dropPrefix x (x ++ y) == y" $ \x y ->
+        dropPrefix x (x ++ y) == (y `asTypeOf` dummy)
+    prop "dropPrefix x y == y || x `isPrefixOf` y" $ \x y ->
+        dropPrefix x y == y || x `isPrefixOf` (y `asTypeOf` dummy)
 
 main :: IO ()
 main = hspec $ do
@@ -347,12 +357,15 @@ main = hspec $ do
     describe "chunks" $ do
         describe "ByteString" $ chunkProps (asLByteString undefined)
         describe "Text" $ chunkProps (asLText undefined)
-    describe "stripSuffix" $ do
-        describe "Text" $ stripSuffixProps (undefined :: Text)
-        describe "LText" $ stripSuffixProps (undefined :: LText)
-        describe "ByteString" $ stripSuffixProps (undefined :: ByteString)
-        describe "LByteString" $ stripSuffixProps (undefined :: LByteString)
-        describe "Seq" $ stripSuffixProps (undefined :: Seq Int)
+    describe "Suffix" $ do
+        describe "list" $ suffixProps (undefined :: [Int])
+        describe "Text" $ suffixProps (undefined :: Text)
+        describe "LText" $ suffixProps (undefined :: LText)
+        describe "ByteString" $ suffixProps (undefined :: ByteString)
+        describe "LByteString" $ suffixProps (undefined :: LByteString)
+        describe "Vector" $ suffixProps (undefined :: Vector Int)
+        describe "UVector" $ suffixProps (undefined :: UVector Int)
+        describe "Seq" $ suffixProps (undefined :: Seq Int)
     describe "replicateM" $ do
         describe "list" $ replicateMProps (undefined :: [Int])
         describe "Vector" $ replicateMProps (undefined :: Vector Int)

--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.0.7.0
+
+* Add `dropPrefix` and `dropSuffix` to `Data.Sequences` [#139](https://github.com/snoyberg/mono-traversable/issues/139)
+
 ## 1.0.6.0
 
 * Add `mapNonNull` function to `Data.NonNull` [#150](https://github.com/snoyberg/mono-traversable/issues/150)

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -8,7 +8,7 @@
 -- | Abstractions over sequential data structures, like lists and vectors.
 module Data.Sequences where
 
-import Data.Maybe (fromJust, isJust)
+import Data.Maybe (fromJust, fromMaybe, isJust)
 import Data.Monoid (Monoid, mconcat, mempty, (<>))
 import Data.MonoTraversable
 import Data.Int (Int64, Int)
@@ -1259,6 +1259,34 @@ stripSuffix x y =
   where
     stripSuffixList :: Eq a => [a] -> [a] -> Maybe [a]
     stripSuffixList x' y' = fmap reverse (stripPrefix (reverse x') (reverse y'))
+
+-- | 'dropPrefix' drops the given prefix from a sequence.  It returns the
+-- original sequence if the sequence doesn't start with the given prefix.
+--
+-- @
+-- > 'dropPrefix' \"foo\" \"foobar\"
+-- \"bar\"
+-- > 'dropPrefix' \"abc\" \"foobar\"
+-- \"foobar\"
+-- @
+--
+-- @since 1.0.7.0
+dropPrefix :: (IsSequence seq, Eq (Element seq)) => seq -> seq -> seq
+dropPrefix x y = fromMaybe y (stripPrefix x y)
+
+-- | 'dropSuffix' drops the given suffix from a sequence.  It returns the
+-- original sequence if the sequence doesn't end with the given suffix.
+--
+-- @
+-- > 'dropSuffix' \"bar\" \"foobar\"
+-- \"foo\"
+-- > 'dropSuffix' \"abc\" \"foobar\"
+-- \"foobar\"
+-- @
+--
+-- @since 1.0.7.0
+dropSuffix :: (IsSequence seq, Eq (Element seq)) => seq -> seq -> seq
+dropSuffix x y = fromMaybe y (stripSuffix x y)
 
 -- | 'ensurePrefix' will add a prefix to a sequence if it doesn't
 -- exist, and otherwise have no effect.


### PR DESCRIPTION
This PR adds the `dropPrefix` and `dropSuffix` functions, as discussed in https://github.com/snoyberg/mono-traversable/issues/139#issuecomment-353729133.

This PR also adds QuickCheck tests for `dropPrefix` and `dropSuffix`.

A `@since` annotation has been added to the functions with version 1.0.7.0.  A note about `dropPrefix and `dropSuffix` has been added to the ChangeLog under version 1.0.7.0.  Please let me know if I need to update these versions.

This PR should close #139.