### PR TITLE
[conduit-combinators] Add warnings about some consumers

### DIFF
--- a/conduit-combinators/src/Data/Conduit/Combinators.hs
+++ b/conduit-combinators/src/Data/Conduit/Combinators.hs
@@ -556,6 +556,14 @@ sourceDirectoryDeep = CF.sourceDirectoryDeep
 
 -- | Ignore a certain number of values in the stream.
 --
+-- Note: since this function doesn't produce anything, you probably want to
+-- use it with ('>>') instead of directly plugging it into a pipeline:
+--
+-- >>> runConduit $ yieldMany [1..5] .| drop 2 .| sinkList
+-- []
+-- >>> runConduit $ yieldMany [1..5] .| (drop 2 >> sinkList)
+-- [3,4,5]
+--
 -- Since 1.0.0
 drop :: Monad m
      => Int
@@ -563,6 +571,9 @@ drop :: Monad m
 INLINE_RULE(drop, n, CL.drop n)
 
 -- | Drop a certain number of elements from a chunked stream.
+--
+-- Note: you likely want to use it with monadic composition. See the docs
+-- for 'drop'.
 --
 -- Since 1.0.0
 dropE :: (Monad m, Seq.IsSequence seq)
@@ -585,6 +596,9 @@ dropE =
 
 -- | Drop all values which match the given predicate.
 --
+-- Note: you likely want to use it with monadic composition. See the docs
+-- for 'drop'.
+--
 -- Since 1.0.0
 dropWhile :: Monad m
           => (a -> Bool)
@@ -597,6 +611,9 @@ dropWhile f =
 {-# INLINE dropWhile #-}
 
 -- | Drop all elements in the chunked stream which match the given predicate.
+--
+-- Note: you likely want to use it with monadic composition. See the docs
+-- for 'drop'.
 --
 -- Since 1.0.0
 dropWhileE :: (Monad m, Seq.IsSequence seq)
@@ -1241,6 +1258,9 @@ STREAMING(find, findC, findS, f)
 
 -- | Apply the action to all values in the stream.
 --
+-- Note: if you want to /pass/ the values instead of /consuming/ them, use
+-- 'iterM' instead.
+--
 -- Subject to fusion
 --
 -- Since 1.0.0
@@ -1248,6 +1268,11 @@ mapM_ :: Monad m => (a -> m ()) -> Consumer a m ()
 INLINE_RULE(mapM_, f, CL.mapM_ f)
 
 -- | Apply the action to all elements in the chunked stream.
+--
+-- Note: the same caveat as with 'mapM_' applies. If you don't want to
+-- consume the values, you can use 'iterM':
+--
+-- > iterM (omapM_ f)
 --
 -- Subject to fusion
 --

--- a/conduit-combinators/src/Data/Conduit/Combinators/Unqualified.hs
+++ b/conduit-combinators/src/Data/Conduit/Combinators/Unqualified.hs
@@ -444,6 +444,14 @@ sourceDirectoryDeep = CC.sourceDirectoryDeep
 
 -- | Ignore a certain number of values in the stream.
 --
+-- Note: since this function doesn't produce anything, you probably want to
+-- use it with ('>>') instead of directly plugging it into a pipeline:
+--
+-- >>> runConduit $ yieldMany [1..5] .| dropC 2 .| sinkList
+-- []
+-- >>> runConduit $ yieldMany [1..5] .| (dropC 2 >> sinkList)
+-- [3,4,5]
+--
 -- Since 1.0.0
 dropC :: Monad m
      => Int
@@ -452,6 +460,9 @@ dropC = CC.drop
 {-# INLINE dropC #-}
 
 -- | Drop a certain number of elements from a chunked stream.
+--
+-- Note: you likely want to use it with monadic composition. See the docs
+-- for 'dropC'.
 --
 -- Since 1.0.0
 dropCE :: (Monad m, Seq.IsSequence seq)
@@ -462,6 +473,9 @@ dropCE = CC.dropE
 
 -- | Drop all values which match the given predicate.
 --
+-- Note: you likely want to use it with monadic composition. See the docs
+-- for 'dropC'.
+--
 -- Since 1.0.0
 dropWhileC :: Monad m
           => (a -> Bool)
@@ -470,6 +484,9 @@ dropWhileC = CC.dropWhile
 {-# INLINE dropWhileC #-}
 
 -- | Drop all elements in the chunked stream which match the given predicate.
+--
+-- Note: you likely want to use it with monadic composition. See the docs
+-- for 'dropC'.
 --
 -- Since 1.0.0
 dropWhileCE :: (Monad m, Seq.IsSequence seq)
@@ -930,12 +947,20 @@ findC = CC.find
 
 -- | Apply the action to all values in the stream.
 --
+-- Note: if you want to /pass/ the values instead of /consuming/ them, use
+-- 'iterM' instead.
+--
 -- Since 1.0.0
 mapM_C :: Monad m => (a -> m ()) -> Consumer a m ()
 mapM_C = CC.mapM_
 {-# INLINE mapM_C #-}
 
 -- | Apply the action to all elements in the chunked stream.
+--
+-- Note: the same caveat as with 'mapM_C' applies. If you don't want to
+-- consume the values, you can use 'iterM':
+--
+-- > iterM (omapM_ f)
 --
 -- Since 1.0.0
 mapM_CE :: (Monad m, MonoFoldable mono) => (Element mono -> m ()) -> Consumer mono m ()


### PR DESCRIPTION
I spent half an hour yesterday trying to understand why a `dropWhileC` in a pipeline doesn't work, so here are some warnings so that others won't make the same mistake.

```diff
 -- | Ignore a certain number of values in the stream.
 --
+-- Note: since this function doesn't produce anything, you probably want to
+-- use it with ('>>') instead of directly plugging it into a pipeline:
+--
+-- >>> runConduit $ yieldMany [1..5] .| drop 2 .| sinkList
+-- []
+-- >>> runConduit $ yieldMany [1..5] .| (drop 2 >> sinkList)
+-- [3,4,5]
+--
 -- Since 1.0.0
 drop :: Monad m
      => Int
      -> Consumer a m ()
INLINE_RULE(drop, n, CL.drop n)
```