### PR TITLE
Bump containers lower bound to 0.5.8

### DIFF
--- a/mono-traversable/package.yaml
+++ b/mono-traversable/package.yaml
@@ -17,7 +17,7 @@ library:
   ghc-options: -Wall
   dependencies:
   - base >= 4.9 && <5
-  - containers >=0.4
+  - containers >=0.5.8
   - unordered-containers >=0.2
   - hashable
   - bytestring >=0.9


### PR DESCRIPTION
Change be3ecf2 uses Seq.!? which is introduced in containers 0.5.8