### PR TITLE
Adding Mono* instances for GHC.Generics types and Data.Proxy.

### DIFF
--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.0.11.0
+
+* Adding monomorphic instances for GHC.Generics and Data.Proxy types
+  [#175](https://github.com/snoyberg/mono-traversable/issues/175)
+
 ## 1.0.10.0
 
 * Make index work on negative indices

--- a/mono-traversable/package.yaml
+++ b/mono-traversable/package.yaml
@@ -1,5 +1,5 @@
 name:        mono-traversable
-version:     1.0.10.0
+version:     1.0.11.0
 synopsis:    Type classes for mapping, folding, and traversing monomorphic containers
 description: Please see the README at <https://www.stackage.org/package/mono-traversable>
 category:    Data


### PR DESCRIPTION
The `Data.MonoTraversable` module is missing the `Mono*` instances for the relevant types from the `GHC.Generics` and `Data.Proxy` modules. It would be convenient to use these in a function which accepts a `MonoTraversable` input. Since the all the types for which instances were added have been included in `base` for the last several versions, this pull request should be a pretty simple and safe addition.