### PR TITLE
Add `filterSet` to `IsSet`

### DIFF
--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,5 +1,6 @@
 ## 1.0.12.0
 * Added `filterSet` to `Data.Containers`
+* Use container specific implementations for `filterSet` and `filterMap`
 
 ## 1.0.11.0
 

--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 1.0.12.0
 * Added `filterSet` to `Data.Containers`
 * Use container specific implementations for `filterSet` and `filterMap`
+  [#178](https://github.com/snoyberg/mono-traversable/pull/178)
 
 ## 1.0.11.0
 

--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,3 +1,6 @@
+## 1.0.12.0
+* Added `filterSet` to `Data.Containers`
+
 ## 1.0.11.0
 
 * Adding monomorphic instances for GHC.Generics and Data.Proxy types

--- a/mono-traversable/package.yaml
+++ b/mono-traversable/package.yaml
@@ -1,5 +1,5 @@
 name:        mono-traversable
-version:     1.0.11.0
+version:     1.0.12.0
 synopsis:    Type classes for mapping, folding, and traversing monomorphic containers
 description: Please see the README at <https://www.stackage.org/package/mono-traversable>
 category:    Data

--- a/mono-traversable/src/Data/Containers.hs
+++ b/mono-traversable/src/Data/Containers.hs
@@ -616,6 +616,8 @@ instance Ord key => IsMap (Map.Map key value) where
     {-# INLINE mapWithKey #-}
     omapKeysWith = Map.mapKeysWith
     {-# INLINE omapKeysWith #-}
+    filterMap = Map.filter
+    {-# INLINE filterMap #-}
 
 #if MIN_VERSION_containers(0, 5, 0)
 -- | This instance uses the functions from "Data.HashMap.Strict".
@@ -653,6 +655,8 @@ instance (Eq key, Hashable key) => IsMap (HashMap.HashMap key value) where
     --unionsWith = HashMap.unionsWith
     --mapWithKey = HashMap.mapWithKey
     --mapKeysWith = HashMap.mapKeysWith
+    filterMap = HashMap.filter
+    {-# INLINE filterMap #-}
 
 #if MIN_VERSION_containers(0, 5, 0)
 -- | This instance uses the functions from "Data.IntMap.Strict".
@@ -703,6 +707,8 @@ instance IsMap (IntMap.IntMap value) where
     omapKeysWith = IntMap.mapKeysWith
     {-# INLINE omapKeysWith #-}
 #endif
+    filterMap = IntMap.filter
+    {-# INLINE filterMap #-}
 
 instance Eq key => IsMap [(key, value)] where
     type MapValue [(key, value)] = value

--- a/mono-traversable/src/Data/Containers.hs
+++ b/mono-traversable/src/Data/Containers.hs
@@ -736,6 +736,12 @@ class (SetContainer set, Element set ~ ContainerKey set) => IsSet set where
     -- | Convert a set to a list.
     setToList :: set -> [Element set]
 
+    -- | Filter values in a set.
+    --
+    -- @since 1.0.12.0
+    filterSet :: (Element set -> Bool) -> set -> set
+    filterSet p = setFromList . filter p . setToList
+
 instance Ord element => IsSet (Set.Set element) where
     insertSet = Set.insert
     {-# INLINE insertSet #-}
@@ -747,6 +753,8 @@ instance Ord element => IsSet (Set.Set element) where
     {-# INLINE setFromList #-}
     setToList = Set.toList
     {-# INLINE setToList #-}
+    filterSet = Set.filter
+    {-# INLINE filterSet #-}
 
 instance (Eq element, Hashable element) => IsSet (HashSet.HashSet element) where
     insertSet = HashSet.insert
@@ -759,6 +767,8 @@ instance (Eq element, Hashable element) => IsSet (HashSet.HashSet element) where
     {-# INLINE setFromList #-}
     setToList = HashSet.toList
     {-# INLINE setToList #-}
+    filterSet = HashSet.filter
+    {-# INLINE filterSet #-}
 
 instance IsSet IntSet.IntSet where
     insertSet = IntSet.insert
@@ -771,6 +781,8 @@ instance IsSet IntSet.IntSet where
     {-# INLINE setFromList #-}
     setToList = IntSet.toList
     {-# INLINE setToList #-}
+    filterSet = IntSet.filter
+    {-# INLINE filterSet #-}
 
 
 -- | Zip operations on 'MonoFunctor's.


### PR DESCRIPTION
I provided implementations for the instances using the corresponding `Set.filter` or equivalent. This probably has better performance than converting to a list and back.

I also noticed that this had not been done for `filterMap` and did the same thing for it, providing `filterMap = Map.filter`, etc.