### PR TITLE
Remove whitespace after '@' in as-patterns

### DIFF
--- a/mono-traversable/src/Data/MonoTraversable.hs
+++ b/mono-traversable/src/Data/MonoTraversable.hs
@@ -1314,7 +1314,7 @@ class MonoFunctor mono => MonoComonad mono where
 instance MonoComonad (ViewL a) where
     oextract ~(x :< _) = x
     {-# INLINE oextract #-}
-    oextend f w@ ~(_ :< xxs) =
+    oextend f w@(~(_ :< xxs)) =
         f w :< case Seq.viewl xxs of
                  EmptyL -> Seq.empty
                  xs     -> case oextend f xs of
@@ -1324,7 +1324,7 @@ instance MonoComonad (ViewL a) where
 instance MonoComonad (ViewR a) where
     oextract ~(_ :> x) = x
     {-# INLINE oextract #-}
-    oextend f w@ ~(xxs :> _) =
+    oextend f w@(~(xxs :> _)) =
         (case Seq.viewr xxs of
            EmptyR -> Seq.empty
            xs     -> case oextend f xs of


### PR DESCRIPTION
Currently, `mono-traversable` has these two lines of code:

https://github.com/snoyberg/mono-traversable/blob/cf3858a4a67859be1518549e06c6976345970396/mono-traversable/src/Data/MonoTraversable.hs#L1317

https://github.com/snoyberg/mono-traversable/blob/cf3858a4a67859be1518549e06c6976345970396/mono-traversable/src/Data/MonoTraversable.hs#L1327

Notice the space after the `@` in each as-pattern. As of GHC proposal [#229](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst), this is a parse error, which means that `mono-traversable` fails to compile on GHC HEAD:

```
src/Data/MonoTraversable.hs:1317:16: error:
    Suffix occurrence of @. For an as-pattern, remove the leading whitespace.
     |
1317 |     oextend f w@ ~(_ :< xxs) =
     |                ^
```

This is easily fixed in a backwards-compatible way by removing the whitespace and adding an extra set of parentheses, which this patch accomplishes. (This is the same [patch that is present in `head.hackage`](https://gitlab.haskell.org/ghc/head.hackage/blob/4ace598831df7b4d1d25d01e6cb1447cf27c3e3c/patches/mono-traversable-1.0.13.0.patch).)