### PR TITLE
Drop dependency on semigroups

### DIFF
--- a/chunked-data/package.yaml
+++ b/chunked-data/package.yaml
@@ -19,7 +19,6 @@ dependencies:
 - text >=1.2
 - containers
 - vector
-- semigroups
 
 library:
   source-dirs: src

--- a/classy-prelude/package.yaml
+++ b/classy-prelude/package.yaml
@@ -35,7 +35,6 @@ library:
   - mono-traversable >=1.0
   - mono-traversable-instances
   #- exceptions >=0.5
-  - semigroups
   - vector-instances
   - time >= 1.5
   #- time-locale-compat

--- a/minlen/package.yaml
+++ b/minlen/package.yaml
@@ -15,7 +15,6 @@ extra-source-files:
 dependencies:
 - base >= 4.10 && <5
 - mono-traversable
-- semigroups
 - transformers
 library:
   source-dirs: src

--- a/mono-traversable-instances/package.yaml
+++ b/mono-traversable-instances/package.yaml
@@ -21,7 +21,6 @@ dependencies:
 - dlist >=0.6 && <1.1
 - dlist-instances ==0.1.*
 - transformers
-- semigroups
 - containers
 library:
   source-dirs: src

--- a/mono-traversable/package.yaml
+++ b/mono-traversable/package.yaml
@@ -26,10 +26,6 @@ library:
   - vector >=0.10
   - vector-algorithms >=0.6
   - split >=0.2
-  when:
-  - condition: impl(ghc <8.0)
-    dependencies:
-    - semigroups >=0.10
 tests:
   test:
     main: main.hs
@@ -45,7 +41,6 @@ tests:
     - transformers
     - vector
     - QuickCheck
-    - semigroups
     - containers
     - unordered-containers
     - foldl


### PR DESCRIPTION
They are not needed on GHC we support.