### PR TITLE
Fix #199: support GHC 9.2 (base 4.16) by putting Option under #if

### DIFF
--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for mono-traversable
 
+## 1.0.15.3
+
+* Compile with GHC 9.2 (`Option` removed from `base-4.16`)
+  [#199](https://github.com/snoyberg/mono-traversable/issues/199)
+
 ## 1.0.15.2
 
 * Support transformers 0.6.0.0 [#196](https://github.com/snoyberg/mono-traversable/issues/196)

--- a/mono-traversable/package.yaml
+++ b/mono-traversable/package.yaml
@@ -1,5 +1,5 @@
 name:        mono-traversable
-version:     1.0.15.2
+version:     1.0.15.3
 synopsis:    Type classes for mapping, folding, and traversing monomorphic containers
 description: Please see the README at <https://www.stackage.org/package/mono-traversable>
 category:    Data

--- a/mono-traversable/src/Data/Containers.hs
+++ b/mono-traversable/src/Data/Containers.hs
@@ -16,7 +16,6 @@ import Data.Hashable (Hashable)
 import qualified Data.Set as Set
 import qualified Data.HashSet as HashSet
 import Data.Monoid (Monoid (..))
-import Data.Semigroup (Semigroup)
 import Data.MonoTraversable (MonoFunctor(..), MonoFoldable, MonoTraversable, Element, GrowingAppend, ofoldl', otoList)
 import Data.Function (on)
 import qualified Data.List as List

--- a/mono-traversable/src/Data/MonoTraversable.hs
+++ b/mono-traversable/src/Data/MonoTraversable.hs
@@ -44,7 +44,7 @@ import           Data.Traversable
 import           Data.Word            (Word8)
 import Data.Int (Int, Int64)
 import           GHC.Exts             (build)
-import           GHC.Generics         ((:.:), (:*:), (:+:)(..), K1(..), M1(..), Par1(..), Rec1(..), U1(..), V1(..))
+import           GHC.Generics         ((:.:), (:*:), (:+:)(..), K1(..), M1(..), Par1(..), Rec1(..), U1(..), V1)
 import           Prelude              (Bool (..), const, Char, flip, IO, Maybe (..), Either (..),
                                        (+), Integral, Ordering (..), compare, fromIntegral, Num, (>=),
                                        (==), seq, otherwise, Eq, Ord, (-), (*))

--- a/mono-traversable/src/Data/MonoTraversable.hs
+++ b/mono-traversable/src/Data/MonoTraversable.hs
@@ -90,7 +90,14 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Storable as VS
 import qualified Data.IntSet as IntSet
-import Data.Semigroup (Semigroup, Option (..), Arg)
+import Data.Semigroup
+  ( Semigroup
+-- Option has been removed in base-4.16 (GHC 9.2)
+#if !MIN_VERSION_base(4,16,0)
+  , Option (..)
+#endif
+  , Arg
+  )
 import qualified Data.ByteString.Unsafe as SU
 import Control.Monad.Trans.Identity (IdentityT)
 
@@ -111,7 +118,9 @@ type instance Element (ViewL a) = a
 type instance Element (ViewR a) = a
 type instance Element (IntMap a) = a
 type instance Element IntSet = Int
+#if !MIN_VERSION_base(4,16,0)
 type instance Element (Option a) = a
+#endif
 type instance Element (NonEmpty a) = a
 type instance Element (Identity a) = a
 type instance Element (r -> a) = a
@@ -184,7 +193,9 @@ instance MonoFunctor (Seq a)
 instance MonoFunctor (ViewL a)
 instance MonoFunctor (ViewR a)
 instance MonoFunctor (IntMap a)
+#if !MIN_VERSION_base(4,16,0)
 instance MonoFunctor (Option a)
+#endif
 instance MonoFunctor (NonEmpty a)
 instance MonoFunctor (Identity a)
 instance MonoFunctor (r -> a)
@@ -352,7 +363,7 @@ class MonoFoldable mono where
     -- /See 'Data.NonNull.ofoldMap1' from "Data.NonNull" for a total version of this function./
     ofoldMap1Ex :: Semigroup m => (Element mono -> m) -> mono -> m
     ofoldMap1Ex f = fromMaybe (Prelude.error "Data.MonoTraversable.ofoldMap1Ex")
-                       . getOption . ofoldMap (Option . Just . f)
+                       . ofoldMap (Just . f)
 
     -- | Right-associative fold of a monomorphic container with no base element.
     --
@@ -630,7 +641,9 @@ instance MonoFoldable (Seq a) where
 instance MonoFoldable (ViewL a)
 instance MonoFoldable (ViewR a)
 instance MonoFoldable (IntMap a)
+#if !MIN_VERSION_base(4,16,0)
 instance MonoFoldable (Option a)
+#endif
 instance MonoFoldable (NonEmpty a)
 instance MonoFoldable (Identity a)
 instance MonoFoldable (Map k v) where
@@ -1009,7 +1022,9 @@ instance MonoTraversable (Seq a)
 instance MonoTraversable (ViewL a)
 instance MonoTraversable (ViewR a)
 instance MonoTraversable (IntMap a)
+#if !MIN_VERSION_base(4,16,0)
 instance MonoTraversable (Option a)
+#endif
 instance MonoTraversable (NonEmpty a)
 instance MonoTraversable (Identity a)
 instance MonoTraversable (Map k v)
@@ -1135,7 +1150,9 @@ instance MonoPointed TL.Text where
 -- Applicative
 instance MonoPointed [a]
 instance MonoPointed (Maybe a)
+#if !MIN_VERSION_base(4,16,0)
 instance MonoPointed (Option a)
+#endif
 instance MonoPointed (NonEmpty a)
 instance MonoPointed (Identity a)
 instance MonoPointed (Vector a)

--- a/mono-traversable/src/Data/MonoTraversable/Unprefixed.hs
+++ b/mono-traversable/src/Data/MonoTraversable/Unprefixed.hs
@@ -14,7 +14,6 @@ module Data.MonoTraversable.Unprefixed where
 
 import Data.Int (Int64)
 import Data.MonoTraversable
-import Data.Semigroup (Semigroup)
 import Data.Monoid (Monoid)
 import Control.Applicative (Applicative)
 

--- a/mono-traversable/src/Data/NonNull.hs
+++ b/mono-traversable/src/Data/NonNull.hs
@@ -49,7 +49,6 @@ import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromMaybe)
 import Data.MonoTraversable
 import Data.Sequences
-import Data.Semigroup (Semigroup (..))
 import Control.Monad.Trans.State.Strict (evalState, state)
 
 data NullError = NullError String deriving (Show, Typeable)


### PR DESCRIPTION
Fix #199: support GHC 9.2 (base 4.16) by putting Option under #if

In base-4.16, Option was removed.

Bump version to 1.0.15.3.

I tested manually that this PR compiles with GHC 8.8 - 9.2.1-rc1.