### PR TITLE
classy-prelude: Support time >= 1.10

### DIFF
--- a/classy-prelude-conduit/package.yaml
+++ b/classy-prelude-conduit/package.yaml
@@ -1,5 +1,5 @@
 name:        classy-prelude-conduit
-version:     1.5.0
+version:     1.5.1
 synopsis:    classy-prelude together with conduit functions
 description: See docs and README at <http://www.stackage.org/package/classy-prelude-conduit>
 category:    Control, Prelude
@@ -24,7 +24,7 @@ library:
   - -fno-warn-orphans
   dependencies:
   - conduit >=1.3 && <1.4
-  - classy-prelude >=1.5.0 && <1.5.1
+  - classy-prelude >=1.5.0 && <1.5.2
   - monad-control
   - resourcet
   - void

--- a/classy-prelude-yesod/package.yaml
+++ b/classy-prelude-yesod/package.yaml
@@ -1,5 +1,5 @@
 name:        classy-prelude-yesod
-version:     1.5.0
+version:     1.5.1
 synopsis:    Provide a classy prelude including common Yesod functionality.
 description: See docs and README at <http://www.stackage.org/package/classy-prelude-yesod>
 category:    Control, Yesod
@@ -14,8 +14,8 @@ extra-source-files:
 
 dependencies:
 - base >= 4.13 && <5
-- classy-prelude >=1.5.0 && <1.5.1
-- classy-prelude-conduit >=1.5.0 && <1.5.1
+- classy-prelude >=1.5.0 && <1.5.2
+- classy-prelude-conduit >=1.5.0 && <1.5.2
 - yesod >=1.2
 - yesod-newsfeed
 - yesod-static

--- a/classy-prelude/ChangeLog.md
+++ b/classy-prelude/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.5.1
+
+* Export a compatiblity shim for `parseTime` as it has been removed in `time-1.10`.
+  See <https://hackage.haskell.org/package/time-1.12/changelog>
+
 ## 1.5.0
 
 * Removed `alwaysSTM` and `alwaysSucceedsSTM`. See

--- a/classy-prelude/package.yaml
+++ b/classy-prelude/package.yaml
@@ -1,5 +1,5 @@
 name:          classy-prelude
-version:       1.5.0
+version:       1.5.1
 synopsis:      A typeclass-based Prelude.
 description:   See docs and README at <http://www.stackage.org/package/classy-prelude>
 category:      Control, Prelude

--- a/classy-prelude/src/ClassyPrelude.hs
+++ b/classy-prelude/src/ClassyPrelude.hs
@@ -47,6 +47,9 @@ module ClassyPrelude
     , traceShowM
       -- ** Time (since 0.6.1)
     , module Data.Time
+#if MIN_VERSION_time(1,10,0)
+    , parseTime
+#endif
       -- ** Generics (since 0.8.1)
     , Generic
       -- ** Transformers (since 0.9.4)
@@ -190,7 +193,9 @@ import Data.Time
     , toGregorian
     , fromGregorian
     , formatTime
+#if !MIN_VERSION_time(1,10,0)
     , parseTime
+#endif
     , parseTimeM
     , getCurrentTime
     , defaultTimeLocale
@@ -620,3 +625,16 @@ getContents = liftIO LTextIO.getContents
 -- @since 1.3.1
 interact :: MonadIO m => (LText -> LText) -> m ()
 interact = liftIO . LTextIO.interact
+
+
+#if MIN_VERSION_time(1,10,0)
+parseTime 
+  :: ParseTime t
+  => TimeLocale -- ^ Time locale.
+  -> String -- ^ Format string.
+  -> String -- ^ Input string.
+  -> Maybe t -- ^ The time value, or 'Nothing' if the input could not be parsed using the given format.
+parseTime = parseTimeM True
+#endif
+
+


### PR DESCRIPTION
This adds support for time >= 1.10 by removing `parseTime` from the re-exports of ClassyPrelude, which was removed in that version. I've bumped the version number and added a Changelog entry.

Alternatively:
 - we could use CPP to only re-export it if it's available
 - redefine it locally and export it if it isn't available

Fixes #204 