### PR TITLE
Add all cabal files, and remove *.cabal from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 cabal.sandbox.config
 .stack-work/
 tarballs/
-*.cabal
 *~

--- a/chunked-data/chunked-data.cabal
+++ b/chunked-data/chunked-data.cabal
@@ -1,0 +1,43 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           chunked-data
+version:        0.3.1
+synopsis:       Typeclasses for dealing with various chunked data representations
+description:    See docs and README at <http://www.stackage.org/package/chunked-data>
+category:       Data
+homepage:       https://github.com/snoyberg/mono-traversable#readme
+bug-reports:    https://github.com/snoyberg/mono-traversable/issues
+author:         Michael Snoyman
+maintainer:     michael@snoyman.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/snoyberg/mono-traversable
+
+library
+  exposed-modules:
+      Data.Builder
+      Data.ChunkedZip
+      Data.IOData
+  other-modules:
+      Paths_chunked_data
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.13 && <5
+    , bytestring >=0.10.2
+    , containers
+    , text >=1.2
+    , transformers
+    , vector
+  default-language: Haskell2010

--- a/classy-prelude-conduit/classy-prelude-conduit.cabal
+++ b/classy-prelude-conduit/classy-prelude-conduit.cabal
@@ -1,0 +1,61 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           classy-prelude-conduit
+version:        1.5.0
+synopsis:       classy-prelude together with conduit functions
+description:    See docs and README at <http://www.stackage.org/package/classy-prelude-conduit>
+category:       Control, Prelude
+homepage:       https://github.com/snoyberg/mono-traversable#readme
+bug-reports:    https://github.com/snoyberg/mono-traversable/issues
+author:         Michael Snoyman
+maintainer:     michael@snoyman.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/snoyberg/mono-traversable
+
+library
+  exposed-modules:
+      ClassyPrelude.Conduit
+  other-modules:
+      Paths_classy_prelude_conduit
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -fno-warn-orphans
+  build-depends:
+      base >=4.13 && <5
+    , bytestring
+    , classy-prelude ==1.5.0.*
+    , conduit ==1.3.*
+    , monad-control
+    , resourcet
+    , transformers
+    , void
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_classy_prelude_conduit
+  hs-source-dirs:
+      test
+  build-depends:
+      QuickCheck
+    , base >=4.13 && <5
+    , bytestring
+    , classy-prelude-conduit
+    , conduit
+    , hspec
+    , transformers
+  default-language: Haskell2010

--- a/classy-prelude-yesod/classy-prelude-yesod.cabal
+++ b/classy-prelude-yesod/classy-prelude-yesod.cabal
@@ -1,0 +1,46 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           classy-prelude-yesod
+version:        1.5.0
+synopsis:       Provide a classy prelude including common Yesod functionality.
+description:    See docs and README at <http://www.stackage.org/package/classy-prelude-yesod>
+category:       Control, Yesod
+homepage:       https://github.com/snoyberg/mono-traversable#readme
+bug-reports:    https://github.com/snoyberg/mono-traversable/issues
+author:         Michael Snoyman
+maintainer:     michael@snoyman.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/snoyberg/mono-traversable
+
+library
+  exposed-modules:
+      ClassyPrelude.Yesod
+  other-modules:
+      Paths_classy_prelude_yesod
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , base >=4.13 && <5
+    , classy-prelude ==1.5.0.*
+    , classy-prelude-conduit ==1.5.0.*
+    , data-default
+    , http-conduit
+    , http-types
+    , persistent >=1.1
+    , yesod >=1.2
+    , yesod-newsfeed
+    , yesod-static
+  default-language: Haskell2010

--- a/classy-prelude/classy-prelude.cabal
+++ b/classy-prelude/classy-prelude.cabal
@@ -1,0 +1,80 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           classy-prelude
+version:        1.5.0.2
+synopsis:       A typeclass-based Prelude.
+description:    See docs and README at <http://www.stackage.org/package/classy-prelude>
+category:       Control, Prelude
+homepage:       https://github.com/snoyberg/mono-traversable#readme
+bug-reports:    https://github.com/snoyberg/mono-traversable/issues
+author:         Michael Snoyman
+maintainer:     michael@snoyman.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/snoyberg/mono-traversable
+
+library
+  exposed-modules:
+      ClassyPrelude
+  other-modules:
+      Paths_classy_prelude
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -fno-warn-orphans
+  build-depends:
+      async
+    , base >=4.13 && <5
+    , basic-prelude >=0.7
+    , bifunctors
+    , bytestring
+    , chunked-data >=0.3
+    , containers >=0.4.2
+    , deepseq
+    , dlist >=0.7
+    , ghc-prim
+    , hashable
+    , mono-traversable >=1.0
+    , mono-traversable-instances
+    , mtl
+    , mutable-containers ==0.3.*
+    , primitive
+    , say
+    , stm
+    , stm-chans >=3
+    , text
+    , time >=1.5
+    , transformers
+    , unliftio >=0.2.1.0
+    , unordered-containers
+    , vector
+    , vector-instances
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: main.hs
+  other-modules:
+      Paths_classy_prelude
+  hs-source-dirs:
+      test
+  ghc-options: -Wall
+  build-depends:
+      QuickCheck
+    , base >=4.13 && <5
+    , classy-prelude
+    , containers
+    , hspec >=1.3
+    , transformers
+    , unordered-containers
+  default-language: Haskell2010

--- a/minlen/minlen.cabal
+++ b/minlen/minlen.cabal
@@ -1,0 +1,38 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           minlen
+version:        0.1.0.0
+synopsis:       Express the minimum length of a container in its type
+description:    See docs and README at <http://www.stackage.org/package/minlen>
+category:       Data
+homepage:       https://github.com/snoyberg/mono-traversable#readme
+bug-reports:    https://github.com/snoyberg/mono-traversable/issues
+author:         Michael Snoyman
+maintainer:     michael@snoyman.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/snoyberg/mono-traversable
+
+library
+  exposed-modules:
+      Data.MinLen
+  other-modules:
+      Paths_minlen
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.13 && <5
+    , mono-traversable
+    , transformers
+  default-language: Haskell2010

--- a/mono-traversable-instances/mono-traversable-instances.cabal
+++ b/mono-traversable-instances/mono-traversable-instances.cabal
@@ -1,0 +1,44 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           mono-traversable-instances
+version:        0.1.1.0
+synopsis:       Extra typeclass instances for mono-traversable
+description:    See docs and README at <http://www.stackage.org/package/mono-traversable-instance>
+category:       Data
+homepage:       https://github.com/snoyberg/mono-traversable#readme
+bug-reports:    https://github.com/snoyberg/mono-traversable/issues
+author:         Michael Snoyman
+maintainer:     michael@fpcomplete.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/snoyberg/mono-traversable
+
+library
+  exposed-modules:
+      Data.MonoTraversable.Instances
+  other-modules:
+      Paths_mono_traversable_instances
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.13 && <5
+    , comonad >=3.0.3
+    , containers
+    , dlist >=0.6 && <1.1
+    , dlist-instances ==0.1.*
+    , mono-traversable ==1.0.*
+    , semigroupoids >=3.0
+    , transformers
+    , vector-instances
+  default-language: Haskell2010

--- a/mono-traversable/mono-traversable.cabal
+++ b/mono-traversable/mono-traversable.cabal
@@ -1,0 +1,89 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           mono-traversable
+version:        1.0.15.3
+synopsis:       Type classes for mapping, folding, and traversing monomorphic containers
+description:    Please see the README at <https://www.stackage.org/package/mono-traversable>
+category:       Data
+homepage:       https://github.com/snoyberg/mono-traversable#readme
+bug-reports:    https://github.com/snoyberg/mono-traversable/issues
+author:         Michael Snoyman, John Wiegley, Greg Weber
+maintainer:     michael@snoyman.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/snoyberg/mono-traversable
+
+library
+  exposed-modules:
+      Data.Containers
+      Data.MonoTraversable
+      Data.MonoTraversable.Unprefixed
+      Data.NonNull
+      Data.Sequences
+  other-modules:
+      Paths_mono_traversable
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >=4.13 && <5
+    , bytestring >=0.9
+    , containers >=0.5.8
+    , hashable
+    , split >=0.2
+    , text >=0.11
+    , transformers >=0.3
+    , unordered-containers >=0.2
+    , vector >=0.10
+    , vector-algorithms >=0.6
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_mono_traversable
+  hs-source-dirs:
+      test
+  ghc-options: -O0
+  build-depends:
+      HUnit
+    , QuickCheck
+    , base
+    , bytestring
+    , containers
+    , foldl
+    , hspec
+    , mono-traversable
+    , text
+    , transformers
+    , unordered-containers
+    , vector
+  default-language: Haskell2010
+
+benchmark sorting
+  type: exitcode-stdio-1.0
+  main-is: sorting.hs
+  other-modules:
+      Paths_mono_traversable
+  hs-source-dirs:
+      bench
+  ghc-options: -Wall -O2
+  build-depends:
+      base
+    , gauge
+    , mono-traversable
+    , mwc-random
+    , vector
+  default-language: Haskell2010

--- a/mutable-containers/mutable-containers.cabal
+++ b/mutable-containers/mutable-containers.cabal
@@ -1,0 +1,98 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           mutable-containers
+version:        0.3.4.1
+synopsis:       Abstactions and concrete implementations of mutable containers
+description:    See docs and README at <http://www.stackage.org/package/mutable-containers>
+category:       Data
+homepage:       https://github.com/snoyberg/mono-traversable#readme
+bug-reports:    https://github.com/snoyberg/mono-traversable/issues
+author:         Michael Snoyman
+maintainer:     michael@fpcomplete.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/snoyberg/mono-traversable
+
+library
+  exposed-modules:
+      Data.Mutable
+  other-modules:
+      Data.Mutable.BRef
+      Data.Mutable.Class
+      Data.Mutable.Deque
+      Data.Mutable.DLList
+      Data.Mutable.PRef
+      Data.Mutable.SRef
+      Data.Mutable.URef
+      Paths_mutable_containers
+  hs-source-dirs:
+      src
+  ghc-options: -O2
+  build-depends:
+      base >=4.13 && <5
+    , containers
+    , ghc-prim
+    , mono-traversable
+    , primitive >=0.5.2.1
+    , vector
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_mutable_containers
+  hs-source-dirs:
+      test
+  build-depends:
+      QuickCheck
+    , base >=4.13 && <5
+    , containers
+    , hspec
+    , mutable-containers
+    , primitive
+    , vector
+  default-language: Haskell2010
+
+benchmark deque
+  type: exitcode-stdio-1.0
+  main-is: deque.hs
+  other-modules:
+      Paths_mutable_containers
+  hs-source-dirs:
+      bench
+  ghc-options: -Wall -O2 -rtsopts
+  build-depends:
+      base >=4.13 && <5
+    , containers
+    , gauge
+    , mutable-containers
+    , vector
+  default-language: Haskell2010
+
+benchmark ref
+  type: exitcode-stdio-1.0
+  main-is: ref.hs
+  other-modules:
+      Paths_mutable_containers
+  hs-source-dirs:
+      bench
+  ghc-options: -Wall -O2 -rtsopts
+  build-depends:
+      base >=4.13 && <5
+    , containers
+    , gauge
+    , mutable-containers
+    , vector
+  default-language: Haskell2010


### PR DESCRIPTION
As stated here: https://www.fpcomplete.com/blog/storing-generated-cabal-files/

> Starting immediately: update docs and Stack templates to recommend checking in generated cabal files. This would involve a few minor doc improvements, and removing *.cabal from a few .gitignore files.

> Personally: I'll start including the generated cabal files in my repos. Since I have a bunch of them, I'll appreciate people sending PRs to modify my .gitignore files and adding the generated files, as you discover them.


I've run into an issue using source-repository-package with haskell.nix, where Cabal complains that mono-traversable has no .cabal file.