### PR TITLE
Don't import Data.Functor.unzip

### DIFF
--- a/classy-prelude/src/ClassyPrelude.hs
+++ b/classy-prelude/src/ClassyPrelude.hs
@@ -153,7 +153,7 @@ module ClassyPrelude
 
 import qualified Prelude
 import Control.Applicative ((<**>),liftA,liftA2,liftA3,Alternative (..), optional)
-import Data.Functor
+import Data.Functor hiding (unzip)
 import Control.Exception (assert)
 import Control.DeepSeq (deepseq, ($!!), force, NFData (..))
 import Control.Monad (when, unless, void, liftM, ap, forever, join, replicateM_, guard, MonadPlus (..), (=<<), (>=>), (<=<), liftM2, liftM3, liftM4, liftM5)


### PR DESCRIPTION
This avoids a name clash for base-19/GHC-9.8 which introduces a new Data.Functor.unzip function.

Let me know if you'd prefer CPP over a warning for older GHCs.