### PR TITLE
Fix #244. Instances for Data.Vector.Strict

### DIFF
--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for mono-traversable
 
+## 1.0.21.0
+
+* Support for vector 0.13.2.0, adding instances for [`Data.Vector.Strict`](https://hackage.haskell.org/package/vector-0.13.2.0/docs/Data-Vector-Strict.html) data structure.
+  [#244](https://github.com/snoyberg/mono-traversable/issues/244)
+
 ## 1.0.20.0
 
 * Added instances for [`Reverse`](https://hackage.haskell.org/package/transformers-0.6.1.1/docs/Data-Functor-Reverse.html#t:Reverse) data structure.

--- a/mono-traversable/mono-traversable.cabal
+++ b/mono-traversable/mono-traversable.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           mono-traversable
-version:        1.0.19.0
+version:        1.0.21.0
 synopsis:       Type classes for mapping, folding, and traversing monomorphic containers
 description:    Please see the README at <https://www.stackage.org/package/mono-traversable>
 category:       Data

--- a/mono-traversable/package.yaml
+++ b/mono-traversable/package.yaml
@@ -1,5 +1,5 @@
 name:        mono-traversable
-version:     1.0.20.0
+version:     1.0.21.0
 synopsis:    Type classes for mapping, folding, and traversing monomorphic containers
 description: Please see the README at <https://www.stackage.org/package/mono-traversable>
 category:    Data

--- a/mono-traversable/src/Data/MonoTraversable.hs
+++ b/mono-traversable/src/Data/MonoTraversable.hs
@@ -28,6 +28,7 @@
 -- instead.\" (Agreed, it's not a great mangling scheme, input is welcome!)
 module Data.MonoTraversable where
 
+
 import           Control.Applicative
 import           Control.Category
 import           Control.Monad        (Monad (..))
@@ -95,6 +96,8 @@ import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Storable as VS
 #if MIN_VERSION_vector(0,13,2)
 import qualified Data.Vector.Strict as VSC
+#else
+{-# DependencyDeprecation "Support for vector < 0.13.2 will be removed when GHC 9.12 reaches Stackage nightly. Please upgrade to vector >= 0.13.2." #-}
 #endif
 import qualified Data.IntSet as IntSet
 import Data.Semigroup

--- a/mono-traversable/src/Data/MonoTraversable.hs
+++ b/mono-traversable/src/Data/MonoTraversable.hs
@@ -28,7 +28,6 @@
 -- instead.\" (Agreed, it's not a great mangling scheme, input is welcome!)
 module Data.MonoTraversable where
 
-
 import           Control.Applicative
 import           Control.Category
 import           Control.Monad        (Monad (..))
@@ -166,6 +165,7 @@ type instance Element (Product f g a) = a
 type instance Element (U.Vector a) = a
 type instance Element (VS.Vector a) = a
 #if MIN_VERSION_vector(0,13,2)
+-- | @since 1.0.21.0
 type instance Element (VSC.Vector a) = a
 #endif
 type instance Element (Arg a b) = b
@@ -268,6 +268,7 @@ instance VS.Storable a => MonoFunctor (VS.Vector a) where
     omap = VS.map
     {-# INLINE omap #-}
 #if MIN_VERSION_vector(0,13,2)
+-- | @since 1.0.21.0
 instance MonoFunctor (VSC.Vector a)
 #endif
 -- | @since 1.0.20.0
@@ -778,6 +779,7 @@ instance VS.Storable a => MonoFoldable (VS.Vector a) where
     {-# INLINE maximumByEx #-}
     {-# INLINE minimumByEx #-}
 #if MIN_VERSION_vector(0,13,2)
+-- | @since 1.0.21.0
 instance MonoFoldable (VSC.Vector a) where
     ofoldr = VSC.foldr
     ofoldl' = VSC.foldl'
@@ -1106,6 +1108,7 @@ instance VS.Storable a => MonoTraversable (VS.Vector a) where
     {-# INLINE otraverse #-}
     {-# INLINE omapM #-}
 #if MIN_VERSION_vector(0,13,2)
+-- | @since 1.0.21.0
 instance MonoTraversable (VSC.Vector a)
 #endif
 instance MonoTraversable (Either a b) where
@@ -1276,6 +1279,7 @@ instance VS.Storable a => MonoPointed (VS.Vector a) where
     opoint = VS.singleton
     {-# INLINE opoint #-}
 #if MIN_VERSION_vector(0,13,2)
+-- | @since 1.0.21.0
 instance MonoPointed (VSC.Vector a)
 #endif
 instance MonoPointed (Either a b) where
@@ -1389,6 +1393,7 @@ instance GrowingAppend (V.Vector a)
 instance U.Unbox a => GrowingAppend (U.Vector a)
 instance VS.Storable a => GrowingAppend (VS.Vector a)
 #if MIN_VERSION_vector(0,13,2)
+-- | @since 1.0.21.0
 instance GrowingAppend (VSC.Vector a)
 #endif
 instance GrowingAppend S.ByteString

--- a/mono-traversable/src/Data/MonoTraversable.hs
+++ b/mono-traversable/src/Data/MonoTraversable.hs
@@ -93,6 +93,9 @@ import Data.Hashable (Hashable)
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Storable as VS
+#if MIN_VERSION_vector(0,13,2)
+import qualified Data.Vector.Strict as VSC
+#endif
 import qualified Data.IntSet as IntSet
 import Data.Semigroup
   ( Semigroup
@@ -159,6 +162,9 @@ type instance Element (Compose f g a) = a
 type instance Element (Product f g a) = a
 type instance Element (U.Vector a) = a
 type instance Element (VS.Vector a) = a
+#if MIN_VERSION_vector(0,13,2)
+type instance Element (VSC.Vector a) = a
+#endif
 type instance Element (Arg a b) = b
 type instance Element ((f :.: g) a) = a
 type instance Element ((f :*: g) a) = a
@@ -258,6 +264,9 @@ instance U.Unbox a => MonoFunctor (U.Vector a) where
 instance VS.Storable a => MonoFunctor (VS.Vector a) where
     omap = VS.map
     {-# INLINE omap #-}
+#if MIN_VERSION_vector(0,13,2)
+instance MonoFunctor (VSC.Vector a)
+#endif
 -- | @since 1.0.20.0
 instance MonoFunctor (f a) => MonoFunctor (Reverse f a) where
     omap f (Reverse t) = Reverse (omap f t)
@@ -765,6 +774,38 @@ instance VS.Storable a => MonoFoldable (VS.Vector a) where
     {-# INLINE unsafeHead #-}
     {-# INLINE maximumByEx #-}
     {-# INLINE minimumByEx #-}
+#if MIN_VERSION_vector(0,13,2)
+instance MonoFoldable (VSC.Vector a) where
+    ofoldr = VSC.foldr
+    ofoldl' = VSC.foldl'
+    otoList = VSC.toList
+    oall = VSC.all
+    oany = VSC.any
+    onull = VSC.null
+    olength = VSC.length
+    ofoldr1Ex = VSC.foldr1
+    ofoldl1Ex' = VSC.foldl1'
+    headEx = VSC.head
+    lastEx = VSC.last
+    unsafeHead = VSC.unsafeHead
+    unsafeLast = VSC.unsafeLast
+    maximumByEx = VSC.maximumBy
+    minimumByEx = VSC.minimumBy
+    {-# INLINE ofoldr #-}
+    {-# INLINE ofoldl' #-}
+    {-# INLINE otoList #-}
+    {-# INLINE oall #-}
+    {-# INLINE oany #-}
+    {-# INLINE onull #-}
+    {-# INLINE olength #-}
+    {-# INLINE ofoldr1Ex #-}
+    {-# INLINE ofoldl1Ex' #-}
+    {-# INLINE headEx #-}
+    {-# INLINE lastEx #-}
+    {-# INLINE unsafeHead #-}
+    {-# INLINE maximumByEx #-}
+    {-# INLINE minimumByEx #-}
+#endif
 instance MonoFoldable (Either a b) where
     ofoldMap f = ofoldr (mappend . f) mempty
     ofoldr f b (Right a) = f a b
@@ -1061,6 +1102,9 @@ instance VS.Storable a => MonoTraversable (VS.Vector a) where
     omapM = otraverse
     {-# INLINE otraverse #-}
     {-# INLINE omapM #-}
+#if MIN_VERSION_vector(0,13,2)
+instance MonoTraversable (VSC.Vector a)
+#endif
 instance MonoTraversable (Either a b) where
     otraverse _ (Left a) = pure (Left a)
     otraverse f (Right b) = fmap Right (f b)
@@ -1228,6 +1272,9 @@ instance U.Unbox a => MonoPointed (U.Vector a) where
 instance VS.Storable a => MonoPointed (VS.Vector a) where
     opoint = VS.singleton
     {-# INLINE opoint #-}
+#if MIN_VERSION_vector(0,13,2)
+instance MonoPointed (VSC.Vector a)
+#endif
 instance MonoPointed (Either a b) where
     opoint = Right
     {-# INLINE opoint #-}
@@ -1338,6 +1385,9 @@ instance GrowingAppend [a]
 instance GrowingAppend (V.Vector a)
 instance U.Unbox a => GrowingAppend (U.Vector a)
 instance VS.Storable a => GrowingAppend (VS.Vector a)
+#if MIN_VERSION_vector(0,13,2)
+instance GrowingAppend (VSC.Vector a)
+#endif
 instance GrowingAppend S.ByteString
 instance GrowingAppend L.ByteString
 instance GrowingAppend T.Text

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -1165,6 +1165,7 @@ instance IsSequence (VSC.Vector a) where
     {-# INLINE filterM #-}
     {-# INLINE replicate #-}
     {-# INLINE replicateM #-}
+    {-# INLINE groupBy #-}
     {-# INLINE tailEx #-}
     {-# INLINE initEx #-}
     {-# INLINE unsafeTail #-}

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -32,6 +32,8 @@ import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Storable as VS
 #if MIN_VERSION_vector(0,13,2)
 import qualified Data.Vector.Strict as VSC
+#else
+{-# DependencyDeprecation "Support for vector < 0.13.2 will be removed when GHC 9.12 reaches Stackage nightly. Please upgrade to vector >= 0.13.2." #-}
 #endif
 import Data.String (IsString)
 import qualified Data.List.NonEmpty as NE
@@ -1139,7 +1141,7 @@ instance IsSequence (VSC.Vector a) where
     unsnoc v
         | VSC.null v = Nothing
         | otherwise = Just (VSC.init v, VSC.last v)
-    --groupBy = VSC.groupBy
+    groupBy = VSC.groupBy
     tailEx = VSC.tail
     initEx = VSC.init
     unsafeTail = VSC.unsafeTail

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -29,6 +30,9 @@ import qualified Data.Sequence as Seq
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Storable as VS
+#if MIN_VERSION_vector(0,13,2)
+import qualified Data.Vector.Strict as VSC
+#endif
 import Data.String (IsString)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.ByteString.Unsafe as SU
@@ -1094,6 +1098,81 @@ instance IsSequence (V.Vector a) where
     {-# INLINE index #-}
     {-# INLINE indexEx #-}
     {-# INLINE unsafeIndex #-}
+
+#if MIN_VERSION_vector(0,13,2)
+instance SemiSequence (VSC.Vector a) where
+    type Index (VSC.Vector a) = Int
+    reverse = VSC.reverse
+    find = VSC.find
+    cons = VSC.cons
+    snoc = VSC.snoc
+
+    sortBy = vectorSortBy
+    intersperse = defaultIntersperse
+    {-# INLINE intersperse #-}
+    {-# INLINE reverse #-}
+    {-# INLINE find #-}
+    {-# INLINE sortBy #-}
+    {-# INLINE cons #-}
+    {-# INLINE snoc #-}
+
+instance IsSequence (VSC.Vector a) where
+    fromList = VSC.fromList
+    lengthIndex = VSC.length
+    replicate = VSC.replicate
+    replicateM = VSC.replicateM
+    filter = VSC.filter
+    filterM = VSC.filterM
+    break = VSC.break
+    span = VSC.span
+    dropWhile = VSC.dropWhile
+    takeWhile = VSC.takeWhile
+    splitAt = VSC.splitAt
+    take = VSC.take
+    drop = VSC.drop
+    unsafeTake = VSC.unsafeTake
+    unsafeDrop = VSC.unsafeDrop
+    partition = VSC.partition
+    uncons v
+        | VSC.null v = Nothing
+        | otherwise = Just (VSC.head v, VSC.tail v)
+    unsnoc v
+        | VSC.null v = Nothing
+        | otherwise = Just (VSC.init v, VSC.last v)
+    --groupBy = VSC.groupBy
+    tailEx = VSC.tail
+    initEx = VSC.init
+    unsafeTail = VSC.unsafeTail
+    unsafeInit = VSC.unsafeInit
+    {-# INLINE fromList #-}
+    {-# INLINE break #-}
+    {-# INLINE span #-}
+    {-# INLINE dropWhile #-}
+    {-# INLINE takeWhile #-}
+    {-# INLINE splitAt #-}
+    {-# INLINE take #-}
+    {-# INLINE unsafeTake #-}
+    {-# INLINE drop #-}
+    {-# INLINE unsafeDrop #-}
+    {-# INLINE partition #-}
+    {-# INLINE uncons #-}
+    {-# INLINE unsnoc #-}
+    {-# INLINE filter #-}
+    {-# INLINE filterM #-}
+    {-# INLINE replicate #-}
+    {-# INLINE replicateM #-}
+    {-# INLINE tailEx #-}
+    {-# INLINE initEx #-}
+    {-# INLINE unsafeTail #-}
+    {-# INLINE unsafeInit #-}
+
+    index = (VSC.!?)
+    indexEx = (VSC.!)
+    unsafeIndex = VSC.unsafeIndex
+    {-# INLINE index #-}
+    {-# INLINE indexEx #-}
+    {-# INLINE unsafeIndex #-}
+#endif
 
 instance U.Unbox a => SemiSequence (U.Vector a) where
     type Index (U.Vector a) = Int

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -1102,6 +1102,7 @@ instance IsSequence (V.Vector a) where
     {-# INLINE unsafeIndex #-}
 
 #if MIN_VERSION_vector(0,13,2)
+-- | @since 1.0.21.0
 instance SemiSequence (VSC.Vector a) where
     type Index (VSC.Vector a) = Int
     reverse = VSC.reverse
@@ -1118,6 +1119,7 @@ instance SemiSequence (VSC.Vector a) where
     {-# INLINE cons #-}
     {-# INLINE snoc #-}
 
+-- | @since 1.0.21.0
 instance IsSequence (VSC.Vector a) where
     fromList = VSC.fromList
     lengthIndex = VSC.length

--- a/mono-traversable/test/Main.hs
+++ b/mono-traversable/test/Main.hs
@@ -33,6 +33,9 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Storable as VS
+#if MIN_VERSION_vector(0,13,2)
+import qualified Data.Vector.Strict as VSC
+#endif
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Semigroup as SG
 import qualified Data.Map as Map
@@ -98,6 +101,9 @@ mapFromListAs xs _ = mapFromList xs
 instance IsString (V.Vector Char) where fromString = V.fromList
 instance IsString (U.Vector Char) where fromString = U.fromList
 instance IsString (VS.Vector Char) where fromString = VS.fromList
+#if MIN_VERSION_vector(0,13,2)
+instance IsString (VSC.Vector Char) where fromString = VSC.fromList
+#endif
 
 main :: IO ()
 main = hspec $ do
@@ -176,6 +182,9 @@ main = hspec $ do
         test "works on lazy bytestrings" L.empty
         test "works on Vector" (V.singleton (1 :: Int))
         test "works on SVector" (VS.singleton (1 :: Int))
+#if MIN_VERSION_vector(0,13,2)
+        test "works on StrictVector" (VSC.singleton (1 :: Int))
+#endif
         test "works on UVector" (U.singleton (1 :: Int))
         test "works on Seq" (Seq.fromList [1 :: Int])
 
@@ -225,6 +234,9 @@ main = hspec $ do
         test "Vector" (mempty :: V.Vector Char)
         test "Unboxed Vector" (mempty :: U.Vector Char)
         test "Storable Vector" (mempty :: VS.Vector Char)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (mempty :: VSC.Vector Char)
+#endif
 
     describe "tails" $ do
         let test typ emptyTyp = describe typ $ do
@@ -240,6 +252,9 @@ main = hspec $ do
         test "Vector" (mempty :: V.Vector Char)
         test "Unboxed Vector" (mempty :: U.Vector Char)
         test "Storable Vector" (mempty :: VS.Vector Char)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (mempty :: VSC.Vector Char)
+#endif
 
     describe "initTails" $ do
         let test typ emptyTyp = describe typ $ do
@@ -255,6 +270,9 @@ main = hspec $ do
         test "Vector" (mempty :: V.Vector Char)
         test "Unboxed Vector" (mempty :: U.Vector Char)
         test "Storable Vector" (mempty :: VS.Vector Char)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (mempty :: VSC.Vector Char)
+#endif
 
     describe "NonNull" $ do
         describe "fromNonEmpty" $ do
@@ -310,6 +328,9 @@ main = hspec $ do
         test "Vector" (V.empty :: V.Vector Int)
         test "Unboxed Vector" (U.empty :: U.Vector Int)
         test "Storable Vector" (VS.empty :: VS.Vector Int)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+#endif
         test "List" ([5 :: Int])
 
     describe "Containers" $ do
@@ -467,6 +488,9 @@ main = hspec $ do
         test "Vector" (V.empty :: V.Vector Int)
         test "Storable Vector" (VS.empty :: VS.Vector Int)
         test "Unboxed Vector" (U.empty :: U.Vector Int)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+#endif
         test "Strict ByteString" S.empty
         test "Lazy ByteString" L.empty
         test "Strict Text" T.empty
@@ -483,6 +507,9 @@ main = hspec $ do
         test "Vector" (V.empty :: V.Vector Int)
         test "Storable Vector" (VS.empty :: VS.Vector Int)
         test "Unboxed Vector" (U.empty :: U.Vector Int)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+#endif
         test "Strict ByteString" S.empty
         test "Lazy ByteString" L.empty
         test "Strict Text" T.empty
@@ -498,6 +525,9 @@ main = hspec $ do
         test "Vector" (V.empty :: V.Vector Int)
         test "Storable Vector" (VS.empty :: VS.Vector Int)
         test "Unboxed Vector" (U.empty :: U.Vector Int)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+#endif
         test "Strict ByteString" S.empty
         test "Lazy ByteString" L.empty
         test "Strict Text" T.empty
@@ -536,6 +566,9 @@ main = hspec $ do
         test "Vector" (V.empty :: V.Vector Int)
         test "Storable Vector" (VS.empty :: VS.Vector Int)
         test "Unboxed Vector" (U.empty :: U.Vector Int)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+#endif
         test "Strict ByteString" S.empty
         test "Lazy ByteString" L.empty
         test "Strict Text" T.empty

--- a/mono-traversable/test/Main.hs
+++ b/mono-traversable/test/Main.hs
@@ -149,6 +149,26 @@ main = hspec $ do
         prop "works on lists" $ \(Positive i) j ->
             ocompareLength (replicate i () :: [()]) j @?= compare i j
 
+    describe "groupBy" $ do
+        let test name dummy = prop name $ \(QCM.NonEmpty xs) -> do
+                let seq' = fromListAs xs dummy
+                let listDef f = Prelude.fmap fromList . List.groupBy f . otoList
+                groupBy (==) seq' @?= listDef (==) seq'
+                groupBy (/=) seq' @?= listDef (/=) seq'
+                groupBy (<) seq' @?= listDef (<) seq'
+                groupBy (>) seq' @?= listDef (>) seq'
+        test "works on lists" ([] :: [Char])
+        test "works on texts" ("" :: Text)
+        test "works on strict bytestrings" S.empty
+        test "works on lazy bytestrings" L.empty
+        test "works on Vector" (V.singleton ('a' :: Char))
+        test "works on SVector" (VS.singleton ('a' :: Char))
+#if MIN_VERSION_vector(0,13,2)
+        test "works on StrictVector" (VSC.singleton ('a' :: Char))
+#endif
+        test "works on UVector" (U.singleton ('a' :: Char))
+        test "works on Seq" (Seq.fromList ['a' :: Char])
+
     describe "groupAll" $ do
         it "works on lists" $ groupAll ("abcabcabc" :: String) @?= ["aaa", "bbb", "ccc"]
         it "works on texts" $ groupAll ("abcabcabc" :: Text)   @?= ["aaa", "bbb", "ccc"]

--- a/mono-traversable/test/Main.hs
+++ b/mono-traversable/test/Main.hs
@@ -35,6 +35,8 @@ import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Storable as VS
 #if MIN_VERSION_vector(0,13,2)
 import qualified Data.Vector.Strict as VSC
+#else
+{-# MissingTests "Tests for Data.Vector.Strict are disabled due to vector < 0.13.2. Please upgrade vector to >= 0.13.2 to enable these tests." #-}
 #endif
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Semigroup as SG
@@ -105,492 +107,482 @@ instance IsString (VS.Vector Char) where fromString = VS.fromList
 instance IsString (VSC.Vector Char) where fromString = VSC.fromList
 #endif
 
--- | Untested functionality due to macros goes heree
-warnUntested :: IO ()
-warnUntested = do
-#if !MIN_VERSION_vector(0,13,2)
-    Prelude.putStrLn "WARNING: Data.Vector.Strict is untested as the vector dependency is too old. Need vector-0.13.2 or greater."
-#endif
-    return ()
-
 main :: IO ()
-main = do
-    warnUntested
-    hspec $ do
-        describe "onull" $ do
-            it "works on empty lists"     $ onull []              @?= True
-            it "works on non-empty lists" $ onull [()]            @?= False
-            it "works on empty texts"     $ onull ("" :: Text)    @?= True
-            it "works on non-empty texts" $ onull ("foo" :: Text) @?= False
+main = hspec $ do
+    describe "onull" $ do
+        it "works on empty lists"     $ onull []              @?= True
+        it "works on non-empty lists" $ onull [()]            @?= False
+        it "works on empty texts"     $ onull ("" :: Text)    @?= True
+        it "works on non-empty texts" $ onull ("foo" :: Text) @?= False
 
-        describe "osum" $ do
-            prop "works on lists" $ \(Small x) (Small y) ->
-                y >= x ==> osum [x..y] @?= ((x + y) * (y - x + 1) `div` (2 :: Int))
+    describe "osum" $ do
+        prop "works on lists" $ \(Small x) (Small y) ->
+            y >= x ==> osum [x..y] @?= ((x + y) * (y - x + 1) `div` (2 :: Int))
 
-        describe "oproduct" $ do
-            prop "works on lists" $ \(Positive x) (Positive y) ->
-                let fact n = oproduct [1..n]
-                 in (y :: Integer) > (x :: Integer) ==>
-                        oproduct [x..y] @?= fact y `div` fact (x - 1)
+    describe "oproduct" $ do
+        prop "works on lists" $ \(Positive x) (Positive y) ->
+            let fact n = oproduct [1..n]
+             in (y :: Integer) > (x :: Integer) ==>
+                    oproduct [x..y] @?= fact y `div` fact (x - 1)
 
-        describe "olength" $ do
-            prop "works on lists" $ \(NonNegative i) ->
-                olength (replicate i () :: [()]) @?= i
-            prop "works on texts" $ \(NonNegative i) ->
-                olength (replicate i 'a' :: Text) @?= i
-            prop "works on lazy bytestrings" $ \(NonNegative (Small i)) ->
-                olength64 (replicate i 6 :: L.ByteString) @?= i
+    describe "olength" $ do
+        prop "works on lists" $ \(NonNegative i) ->
+            olength (replicate i () :: [()]) @?= i
+        prop "works on texts" $ \(NonNegative i) ->
+            olength (replicate i 'a' :: Text) @?= i
+        prop "works on lazy bytestrings" $ \(NonNegative (Small i)) ->
+            olength64 (replicate i 6 :: L.ByteString) @?= i
 
-        describe "omap" $ do
-            prop "works on lists" $ \xs ->
-                omap (+1) xs @?= map (+1) (xs :: [Int])
-            prop "works on lazy bytestrings" $ \xs ->
-                omap (+1) (fromList xs :: L.ByteString) @?= fromList (map (+1) xs)
-            prop "works on texts" $ \xs ->
-                omap succ (fromList xs :: Text) @?= fromList (map succ xs)
+    describe "omap" $ do
+        prop "works on lists" $ \xs ->
+            omap (+1) xs @?= map (+1) (xs :: [Int])
+        prop "works on lazy bytestrings" $ \xs ->
+            omap (+1) (fromList xs :: L.ByteString) @?= fromList (map (+1) xs)
+        prop "works on texts" $ \xs ->
+            omap succ (fromList xs :: Text) @?= fromList (map succ xs)
 
-        describe "oconcatMap" $ do
-            prop "works on lists" $ \xs ->
-                oconcatMap (: []) xs @?= (xs :: [Int])
+    describe "oconcatMap" $ do
+        prop "works on lists" $ \xs ->
+            oconcatMap (: []) xs @?= (xs :: [Int])
 
-        describe "ocompareLength" $ do
-            prop "works on lists" $ \(Positive i) j ->
-                ocompareLength (replicate i () :: [()]) j @?= compare i j
+    describe "ocompareLength" $ do
+        prop "works on lists" $ \(Positive i) j ->
+            ocompareLength (replicate i () :: [()]) j @?= compare i j
 
-        describe "groupAll" $ do
-            it "works on lists" $ groupAll ("abcabcabc" :: String) @?= ["aaa", "bbb", "ccc"]
-            it "works on texts" $ groupAll ("abcabcabc" :: Text)   @?= ["aaa", "bbb", "ccc"]
+    describe "groupAll" $ do
+        it "works on lists" $ groupAll ("abcabcabc" :: String) @?= ["aaa", "bbb", "ccc"]
+        it "works on texts" $ groupAll ("abcabcabc" :: Text)   @?= ["aaa", "bbb", "ccc"]
 
-        describe "unsnoc" $ do
-            let test name dummy = prop name $ \(QCM.NonEmpty xs) ->
-                    let seq' = fromListAs xs dummy
-                     in case unsnoc seq' of
-                            Just (y, z) -> do
-                                y SG.<> singleton z @?= seq'
-                                snoc y z            @?= seq'
-                                otoList (snoc y z)  @?= xs
-                            Nothing -> expectationFailure "unsnoc returned Nothing"
-            test "works on lists" ([] :: [Int])
-            test "works on texts" ("" :: Text)
-            test "works on lazy bytestrings" L.empty
+    describe "unsnoc" $ do
+        let test name dummy = prop name $ \(QCM.NonEmpty xs) ->
+                let seq' = fromListAs xs dummy
+                 in case unsnoc seq' of
+                        Just (y, z) -> do
+                            y SG.<> singleton z @?= seq'
+                            snoc y z            @?= seq'
+                            otoList (snoc y z)  @?= xs
+                        Nothing -> expectationFailure "unsnoc returned Nothing"
+        test "works on lists" ([] :: [Int])
+        test "works on texts" ("" :: Text)
+        test "works on lazy bytestrings" L.empty
 
-        describe "index" $ do
-            let test name dummy = prop name $
-                  \i' (QCM.NonEmpty xs) ->
-                    let seq' = fromListAs xs dummy
-                        mx   = index xs (fromIntegral i)
-                        i    = fromIntegral (i' :: Int)
+    describe "index" $ do
+        let test name dummy = prop name $
+              \i' (QCM.NonEmpty xs) ->
+                let seq' = fromListAs xs dummy
+                    mx   = index xs (fromIntegral i)
+                    i    = fromIntegral (i' :: Int)
+                 in do
+                    mx @?= index seq' i
+                    case mx of
+                        Nothing -> return ()
+                        Just x  -> indexEx seq' i @?= x
+        test "works on lists" ([] :: [Int])
+        test "works on strict texts" ("" :: Text)
+        test "works on lazy texts" ("" :: TL.Text)
+        test "works on strict bytestrings" S.empty
+        test "works on lazy bytestrings" L.empty
+        test "works on Vector" (V.singleton (1 :: Int))
+        test "works on SVector" (VS.singleton (1 :: Int))
+#if MIN_VERSION_vector(0,13,2)
+        test "works on StrictVector" (VSC.singleton (1 :: Int))
+#endif
+        test "works on UVector" (U.singleton (1 :: Int))
+        test "works on Seq" (Seq.fromList [1 :: Int])
+
+    describe "groupAllOn" $ do
+        it "works on lists" $
+            groupAllOn (`mod` 3) ([1..9] :: [Int]) @?= [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
+
+    describe "breakWord" $ do
+        let test x y z = it (show (x, y, z)) $ breakWord (x :: Text) @?= (y, z)
+        test "hello world" "hello" "world"
+        test "hello     world" "hello" "world"
+        test "hello\r\nworld" "hello" "world"
+        test "hello there  world" "hello" "there  world"
+        test "" "" ""
+        test "hello    \n\r\t" "hello" ""
+
+    describe "breakLine" $ do
+        let test x y z = it (show (x, y, z)) $ breakLine (x :: Text) @?= (y, z)
+        test "hello world" "hello world" ""
+        test "hello\r\n world" "hello" " world"
+        test "hello\n world" "hello" " world"
+        test "hello\r world" "hello\r world" ""
+        test "hello\r\nworld" "hello" "world"
+        test "hello\r\nthere\nworld" "hello" "there\nworld"
+        test "hello\n\r\nworld" "hello" "\r\nworld"
+        test "" "" ""
+
+    describe "omapM_" $ do
+        let test typ dummy = prop typ $ \input ->
+                input @?= execWriter (omapM_ (tell . return) (fromListAs input dummy))
+        test "works on strict bytestrings" S.empty
+        test "works on lazy bytestrings" L.empty
+        test "works on strict texts" T.empty
+        test "works on lazy texts" TL.empty
+
+    describe "inits" $ do
+        let test typ emptyTyp = describe typ $ do
+              it "empty" $ inits emptyTyp @?= [""]
+              it "one element" $ inits ("a" <> emptyTyp) @?= ["", "a"]
+              it "two elements" $ inits ("ab" <> emptyTyp) @?= ["", "a", "ab"]
+        test "String" (mempty :: String)
+        test "StrictBytestring" S.empty
+        test "LazyBytestring" L.empty
+        test "StrictText" T.empty
+        test "LazyText" TL.empty
+        test "Seq" Seq.empty
+        test "Vector" (mempty :: V.Vector Char)
+        test "Unboxed Vector" (mempty :: U.Vector Char)
+        test "Storable Vector" (mempty :: VS.Vector Char)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (mempty :: VSC.Vector Char)
+#endif
+
+    describe "tails" $ do
+        let test typ emptyTyp = describe typ $ do
+              it "empty" $ tails emptyTyp @?= [""]
+              it "one element" $ tails ("a" <> emptyTyp) @?= ["a", ""]
+              it "two elements" $ tails ("ab" <> emptyTyp) @?= ["ab", "b", ""]
+        test "String" (mempty :: String)
+        test "StrictBytestring" S.empty
+        test "LazyBytestring" L.empty
+        test "StrictText" T.empty
+        test "LazyText" TL.empty
+        test "Seq" Seq.empty
+        test "Vector" (mempty :: V.Vector Char)
+        test "Unboxed Vector" (mempty :: U.Vector Char)
+        test "Storable Vector" (mempty :: VS.Vector Char)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (mempty :: VSC.Vector Char)
+#endif
+
+    describe "initTails" $ do
+        let test typ emptyTyp = describe typ $ do
+              it "empty" $ initTails emptyTyp @?= [("","")]
+              it "one element" $ initTails ("a" <> emptyTyp) @?= [("","a"), ("a","")]
+              it "two elements" $ initTails ("ab" <> emptyTyp) @?= [("","ab"), ("a","b"), ("ab","")]
+        test "String" (mempty :: String)
+        test "StrictBytestring" S.empty
+        test "LazyBytestring" L.empty
+        test "StrictText" T.empty
+        test "LazyText" TL.empty
+        test "Seq" Seq.empty
+        test "Vector" (mempty :: V.Vector Char)
+        test "Unboxed Vector" (mempty :: U.Vector Char)
+        test "Storable Vector" (mempty :: VS.Vector Char)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (mempty :: VSC.Vector Char)
+#endif
+
+    describe "NonNull" $ do
+        describe "fromNonEmpty" $ do
+            prop "toMinList" $ \(NonEmpty' ne) ->
+                (NE.toList ne :: [Int]) @?= NN.toNullable (NN.toMinList ne)
+        describe "toNonEmpty" $ do
+            it "converts nonnull to nonempty" $ do
+                NN.toNonEmpty (NN.impureNonNull [1,2,3]) @?= NE.fromList [1,2,3]
+
+        describe "mapNonNull" $ do
+            prop "mapNonNull id == id" $ \x xs ->
+                let nonNull = NN.ncons x (xs :: [Int])
+                in NN.mapNonNull Prelude.id nonNull @?= nonNull
+            prop "mapNonNull (f . g) == mapNonNull f . mapNonNull g" $
+                \(Fn (f :: Integer -> String)) (Fn (g :: Int -> Integer)) x xs ->
+                    let nns = NN.ncons x (xs :: [Int])
+                    in NN.mapNonNull (f . g) nns @?= NN.mapNonNull f (NN.mapNonNull g nns)
+
+        let -- | Type restricted 'NN.ncons'
+            nconsAs :: IsSequence seq => Element seq -> [Element seq] -> seq -> NN.NonNull seq
+            nconsAs x xs _ = NN.ncons x (fromList xs)
+
+            test :: (IsSequence typ, Ord (Element typ), Arbitrary (Element typ), Show (Element typ), Show typ, Eq typ, Eq (Element typ))
+                 => String -> typ -> Spec
+            test typ du = describe typ $ do
+                prop "head" $ \x xs ->
+                    NN.head (nconsAs x xs du) @?= x
+                prop "tail" $ \x xs ->
+                    NN.tail (nconsAs x xs du) @?= fromList xs
+                prop "last" $ \x xs ->
+                    NN.last (reverse $ nconsAs x xs du) @?= x
+                prop "init" $ \x xs ->
+                    NN.init (reverse $ nconsAs x xs du) @?= reverse (fromList xs)
+                prop "maximum" $ \x xs ->
+                    NN.maximum (nconsAs x xs du) @?= Prelude.maximum (x:xs)
+                prop "maximumBy" $ \x xs ->
+                    NN.maximumBy compare (nconsAs x xs du) @?= Prelude.maximum (x:xs)
+                prop "minimum" $ \x xs ->
+                    NN.minimum (nconsAs x xs du) @?= Prelude.minimum (x:xs)
+                prop "minimumBy" $ \x xs ->
+                    NN.minimumBy compare (nconsAs x xs du) @?= Prelude.minimum (x:xs)
+                prop "ofoldMap1" $ \x xs ->
+                    SG.getMax (NN.ofoldMap1 SG.Max $ nconsAs x xs du) @?= Prelude.maximum (x:xs)
+                prop "ofoldr1" $ \x xs ->
+                    NN.ofoldr1 Prelude.min (nconsAs x xs du) @?= Prelude.minimum (x:xs)
+                prop "ofoldl1'" $ \x xs ->
+                    NN.ofoldl1' Prelude.min (nconsAs x xs du) @?= Prelude.minimum (x:xs)
+
+        test "Strict ByteString" S.empty
+        test "Lazy ByteString" L.empty
+        test "Strict Text" T.empty
+        test "Lazy Text" TL.empty
+        test "Vector" (V.empty :: V.Vector Int)
+        test "Unboxed Vector" (U.empty :: U.Vector Int)
+        test "Storable Vector" (VS.empty :: VS.Vector Int)
+#if MIN_VERSION_vector(0,13,2)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+#endif
+        test "List" ([5 :: Int])
+
+    describe "Containers" $ do
+        let test typ dummy xlookup xinsert xdelete = describe typ $ do
+                prop "difference" $ \(DuplPairs xs) (DuplPairs ys) ->
+                    let m1 = mapFromList xs `difference` mapFromList ys
+                        m2 = mapFromListAs (xs `difference` ys) dummy
+                     in m1 @?= m2
+
+                prop "lookup" $ \(DuplPairs xs) -> indexIn xs $ \k ->
+                    let m = mapFromListAs xs dummy
+                        v1 = lookup k m
+                    in do
+                        v1 @?= lookup k xs
+                        v1 @?= xlookup k m
+
+                prop "insert" $ \(DuplPairs xs) v -> indexIn xs $ \k ->
+                    let m = mapFromListAs xs dummy
+                        m1 = insertMap k v m
                      in do
-                        mx @?= index seq' i
-                        case mx of
-                            Nothing -> return ()
-                            Just x  -> indexEx seq' i @?= x
-            test "works on lists" ([] :: [Int])
-            test "works on strict texts" ("" :: Text)
-            test "works on lazy texts" ("" :: TL.Text)
-            test "works on strict bytestrings" S.empty
-            test "works on lazy bytestrings" L.empty
-            test "works on Vector" (V.singleton (1 :: Int))
-            test "works on SVector" (VS.singleton (1 :: Int))
-#if MIN_VERSION_vector(0,13,2)
-            test "works on StrictVector" (VSC.singleton (1 :: Int))
-#endif
-            test "works on UVector" (U.singleton (1 :: Int))
-            test "works on Seq" (Seq.fromList [1 :: Int])
+                        m1 @?= mapFromList (insertMap k v xs)
+                        m1 @?= xinsert k v m
 
-        describe "groupAllOn" $ do
-            it "works on lists" $
-                groupAllOn (`mod` 3) ([1..9] :: [Int]) @?= [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
+                prop "delete" $ \(DuplPairs xs) -> indexIn xs $ \k ->
+                    let m = mapFromListAs xs dummy
+                        m1 = deleteMap k m
+                     in do
+                        m1 @?= mapFromList (deleteMap k xs)
+                        m1 @?= xdelete k m
 
-        describe "breakWord" $ do
-            let test x y z = it (show (x, y, z)) $ breakWord (x :: Text) @?= (y, z)
-            test "hello world" "hello" "world"
-            test "hello     world" "hello" "world"
-            test "hello\r\nworld" "hello" "world"
-            test "hello there  world" "hello" "there  world"
-            test "" "" ""
-            test "hello    \n\r\t" "hello" ""
+                prop "singletonMap" $ \k v ->
+                    singletonMap k v @?= (mapFromListAs [(k, v)] dummy)
 
-        describe "breakLine" $ do
-            let test x y z = it (show (x, y, z)) $ breakLine (x :: Text) @?= (y, z)
-            test "hello world" "hello world" ""
-            test "hello\r\n world" "hello" " world"
-            test "hello\n world" "hello" " world"
-            test "hello\r world" "hello\r world" ""
-            test "hello\r\nworld" "hello" "world"
-            test "hello\r\nthere\nworld" "hello" "there\nworld"
-            test "hello\n\r\nworld" "hello" "\r\nworld"
-            test "" "" ""
+                prop "findWithDefault" $ \(DuplPairs xs) k v ->
+                    findWithDefault v k (mapFromListAs xs dummy)
+                        @?= findWithDefault v k xs
 
-        describe "omapM_" $ do
-            let test typ dummy = prop typ $ \input ->
-                    input @?= execWriter (omapM_ (tell . return) (fromListAs input dummy))
-            test "works on strict bytestrings" S.empty
-            test "works on lazy bytestrings" L.empty
-            test "works on strict texts" T.empty
-            test "works on lazy texts" TL.empty
+                prop "insertWith" $ \(DuplPairs xs) k v ->
+                    insertWith (+) k v (mapFromListAs xs dummy)
+                        @?= mapFromList (insertWith (+) k v xs)
 
-        describe "inits" $ do
-            let test typ emptyTyp = describe typ $ do
-                  it "empty" $ inits emptyTyp @?= [""]
-                  it "one element" $ inits ("a" <> emptyTyp) @?= ["", "a"]
-                  it "two elements" $ inits ("ab" <> emptyTyp) @?= ["", "a", "ab"]
-            test "String" (mempty :: String)
-            test "StrictBytestring" S.empty
-            test "LazyBytestring" L.empty
-            test "StrictText" T.empty
-            test "LazyText" TL.empty
-            test "Seq" Seq.empty
-            test "Vector" (mempty :: V.Vector Char)
-            test "Unboxed Vector" (mempty :: U.Vector Char)
-            test "Storable Vector" (mempty :: VS.Vector Char)
-#if MIN_VERSION_vector(0,13,2)
-            test "Strict Vector" (mempty :: VSC.Vector Char)
-#endif
+                prop "insertWithKey" $ \(DuplPairs xs) k v ->
+                    let m = mapFromListAs xs dummy
+                        f x y z = x + y + z
+                     in insertWithKey f k v m
+                            @?= mapFromList (insertWithKey f k v xs)
 
-        describe "tails" $ do
-            let test typ emptyTyp = describe typ $ do
-                  it "empty" $ tails emptyTyp @?= [""]
-                  it "one element" $ tails ("a" <> emptyTyp) @?= ["a", ""]
-                  it "two elements" $ tails ("ab" <> emptyTyp) @?= ["ab", "b", ""]
-            test "String" (mempty :: String)
-            test "StrictBytestring" S.empty
-            test "LazyBytestring" L.empty
-            test "StrictText" T.empty
-            test "LazyText" TL.empty
-            test "Seq" Seq.empty
-            test "Vector" (mempty :: V.Vector Char)
-            test "Unboxed Vector" (mempty :: U.Vector Char)
-            test "Storable Vector" (mempty :: VS.Vector Char)
-#if MIN_VERSION_vector(0,13,2)
-            test "Strict Vector" (mempty :: VSC.Vector Char)
-#endif
+                prop "insertLookupWithKey" $ \(DuplPairs xs) k v ->
+                    let m = mapFromListAs xs dummy
+                        f x y z = x + y + z
+                     in insertLookupWithKey f k v m @?=
+                            second mapFromList (insertLookupWithKey f k v xs)
 
-        describe "initTails" $ do
-            let test typ emptyTyp = describe typ $ do
-                  it "empty" $ initTails emptyTyp @?= [("","")]
-                  it "one element" $ initTails ("a" <> emptyTyp) @?= [("","a"), ("a","")]
-                  it "two elements" $ initTails ("ab" <> emptyTyp) @?= [("","ab"), ("a","b"), ("ab","")]
-            test "String" (mempty :: String)
-            test "StrictBytestring" S.empty
-            test "LazyBytestring" L.empty
-            test "StrictText" T.empty
-            test "LazyText" TL.empty
-            test "Seq" Seq.empty
-            test "Vector" (mempty :: V.Vector Char)
-            test "Unboxed Vector" (mempty :: U.Vector Char)
-            test "Storable Vector" (mempty :: VS.Vector Char)
-#if MIN_VERSION_vector(0,13,2)
-            test "Strict Vector" (mempty :: VSC.Vector Char)
-#endif
+                prop "adjustMap" $ \(DuplPairs xs) k ->
+                    adjustMap succ k (mapFromListAs xs dummy)
+                        @?= mapFromList (adjustMap succ k xs)
 
-        describe "NonNull" $ do
-            describe "fromNonEmpty" $ do
-                prop "toMinList" $ \(NonEmpty' ne) ->
-                    (NE.toList ne :: [Int]) @?= NN.toNullable (NN.toMinList ne)
-            describe "toNonEmpty" $ do
-                it "converts nonnull to nonempty" $ do
-                    NN.toNonEmpty (NN.impureNonNull [1,2,3]) @?= NE.fromList [1,2,3]
+                prop "adjustWithKey" $ \(DuplPairs xs) k ->
+                    adjustWithKey (+) k (mapFromListAs xs dummy)
+                        @?= mapFromList (adjustWithKey (+) k xs)
 
-            describe "mapNonNull" $ do
-                prop "mapNonNull id == id" $ \x xs ->
-                    let nonNull = NN.ncons x (xs :: [Int])
-                    in NN.mapNonNull Prelude.id nonNull @?= nonNull
-                prop "mapNonNull (f . g) == mapNonNull f . mapNonNull g" $
-                    \(Fn (f :: Integer -> String)) (Fn (g :: Int -> Integer)) x xs ->
-                        let nns = NN.ncons x (xs :: [Int])
-                        in NN.mapNonNull (f . g) nns @?= NN.mapNonNull f (NN.mapNonNull g nns)
+                prop "updateMap" $ \(DuplPairs xs) k ->
+                    let f i = if i < 0 then Nothing else Just $ i * 2
+                     in updateMap f k (mapFromListAs xs dummy)
+                            @?= mapFromList (updateMap f k xs)
 
-            let -- | Type restricted 'NN.ncons'
-                nconsAs :: IsSequence seq => Element seq -> [Element seq] -> seq -> NN.NonNull seq
-                nconsAs x xs _ = NN.ncons x (fromList xs)
+                prop "updateWithKey" $ \(DuplPairs xs) k' ->
+                    let f k i = if i < 0 then Nothing else Just $ i * k
+                     in updateWithKey f k' (mapFromListAs xs dummy)
+                            @?= mapFromList (updateWithKey f k' xs)
 
-                test :: (IsSequence typ, Ord (Element typ), Arbitrary (Element typ), Show (Element typ), Show typ, Eq typ, Eq (Element typ))
-                     => String -> typ -> Spec
-                test typ du = describe typ $ do
-                    prop "head" $ \x xs ->
-                        NN.head (nconsAs x xs du) @?= x
-                    prop "tail" $ \x xs ->
-                        NN.tail (nconsAs x xs du) @?= fromList xs
-                    prop "last" $ \x xs ->
-                        NN.last (reverse $ nconsAs x xs du) @?= x
-                    prop "init" $ \x xs ->
-                        NN.init (reverse $ nconsAs x xs du) @?= reverse (fromList xs)
-                    prop "maximum" $ \x xs ->
-                        NN.maximum (nconsAs x xs du) @?= Prelude.maximum (x:xs)
-                    prop "maximumBy" $ \x xs ->
-                        NN.maximumBy compare (nconsAs x xs du) @?= Prelude.maximum (x:xs)
-                    prop "minimum" $ \x xs ->
-                        NN.minimum (nconsAs x xs du) @?= Prelude.minimum (x:xs)
-                    prop "minimumBy" $ \x xs ->
-                        NN.minimumBy compare (nconsAs x xs du) @?= Prelude.minimum (x:xs)
-                    prop "ofoldMap1" $ \x xs ->
-                        SG.getMax (NN.ofoldMap1 SG.Max $ nconsAs x xs du) @?= Prelude.maximum (x:xs)
-                    prop "ofoldr1" $ \x xs ->
-                        NN.ofoldr1 Prelude.min (nconsAs x xs du) @?= Prelude.minimum (x:xs)
-                    prop "ofoldl1'" $ \x xs ->
-                        NN.ofoldl1' Prelude.min (nconsAs x xs du) @?= Prelude.minimum (x:xs)
+                prop "updateLookupWithKey" $ \(DuplPairs xs) k' ->
+                    let f k i = if i < 0 then Nothing else Just $ i * k
+                     in updateLookupWithKey f k' (mapFromListAs xs dummy)
+                            @?= second mapFromList (updateLookupWithKey f k' xs)
 
-            test "Strict ByteString" S.empty
-            test "Lazy ByteString" L.empty
-            test "Strict Text" T.empty
-            test "Lazy Text" TL.empty
-            test "Vector" (V.empty :: V.Vector Int)
-            test "Unboxed Vector" (U.empty :: U.Vector Int)
-            test "Storable Vector" (VS.empty :: VS.Vector Int)
-#if MIN_VERSION_vector(0,13,2)
-            test "Strict Vector" (VSC.empty :: VSC.Vector Int)
-#endif
-            test "List" ([5 :: Int])
+                prop "alter" $ \(DuplPairs xs) k ->
+                    let m = mapFromListAs xs dummy
+                        f Nothing = Just (-1)
+                        f (Just i) = if i < 0 then Nothing else Just (i * 2)
+                     in lookup k (alterMap f k m) @?= f (lookup k m)
 
-        describe "Containers" $ do
-            let test typ dummy xlookup xinsert xdelete = describe typ $ do
-                    prop "difference" $ \(DuplPairs xs) (DuplPairs ys) ->
-                        let m1 = mapFromList xs `difference` mapFromList ys
-                            m2 = mapFromListAs (xs `difference` ys) dummy
-                         in m1 @?= m2
+                prop "unionWith" $ \(DuplPairs xs) (DuplPairs ys) ->
+                    let m1 = unionWith (+)
+                                (mapFromListAs xs dummy)
+                                (mapFromListAs ys dummy)
+                        m2 = mapFromList (unionWith (+) xs ys)
+                     in m1 @?= m2
 
-                    prop "lookup" $ \(DuplPairs xs) -> indexIn xs $ \k ->
-                        let m = mapFromListAs xs dummy
-                            v1 = lookup k m
-                        in do
-                            v1 @?= lookup k xs
-                            v1 @?= xlookup k m
+                prop "unionWithKey" $ \(DuplPairs xs) (DuplPairs ys) ->
+                    let f k x y = k + x + y
+                        m1 = unionWithKey f
+                                (mapFromListAs xs dummy)
+                                (mapFromListAs ys dummy)
+                        m2 = mapFromList (unionWithKey f xs ys)
+                     in m1 @?= m2
 
-                    prop "insert" $ \(DuplPairs xs) v -> indexIn xs $ \k ->
-                        let m = mapFromListAs xs dummy
-                            m1 = insertMap k v m
-                         in do
-                            m1 @?= mapFromList (insertMap k v xs)
-                            m1 @?= xinsert k v m
+                prop "unionsWith" $ \(SmallList xss) ->
+                    let duplXss = map unDupl xss
+                        ms = map mapFromList duplXss `asTypeOf` [dummy]
+                     in unionsWith (+) ms
+                            @?= mapFromList (unionsWith (+) duplXss)
 
-                    prop "delete" $ \(DuplPairs xs) -> indexIn xs $ \k ->
-                        let m = mapFromListAs xs dummy
-                            m1 = deleteMap k m
-                         in do
-                            m1 @?= mapFromList (deleteMap k xs)
-                            m1 @?= xdelete k m
+                prop "mapWithKey" $ \(DuplPairs xs) ->
+                    let m1 = mapWithKey (+) (mapFromList xs) `asTypeOf` dummy
+                        m2 = mapFromList $ mapWithKey (+) xs
+                     in m1 @?= m2
 
-                    prop "singletonMap" $ \k v ->
-                        singletonMap k v @?= (mapFromListAs [(k, v)] dummy)
+                prop "omapKeysWith" $ \(DuplPairs xs) ->
+                    let f = flip mod 5
+                        m1 = omapKeysWith (+) f (mapFromList xs) `asTypeOf` dummy
+                        m2 = mapFromList $ omapKeysWith (+) f xs
+                     in m1 @?= m2
 
-                    prop "findWithDefault" $ \(DuplPairs xs) k v ->
-                        findWithDefault v k (mapFromListAs xs dummy)
-                            @?= findWithDefault v k xs
+        test "Data.Map" (Map.empty :: Map.Map Int Int)
+            Map.lookup Map.insert Map.delete
+        test "Data.IntMap" (IntMap.empty :: IntMap.IntMap Int)
+            IntMap.lookup IntMap.insert IntMap.delete
+        test "Data.HashMap" (HashMap.empty :: HashMap.HashMap Int Int)
+            HashMap.lookup HashMap.insert HashMap.delete
 
-                    prop "insertWith" $ \(DuplPairs xs) k v ->
-                        insertWith (+) k v (mapFromListAs xs dummy)
-                            @?= mapFromList (insertWith (+) k v xs)
-
-                    prop "insertWithKey" $ \(DuplPairs xs) k v ->
-                        let m = mapFromListAs xs dummy
-                            f x y z = x + y + z
-                         in insertWithKey f k v m
-                                @?= mapFromList (insertWithKey f k v xs)
-
-                    prop "insertLookupWithKey" $ \(DuplPairs xs) k v ->
-                        let m = mapFromListAs xs dummy
-                            f x y z = x + y + z
-                         in insertLookupWithKey f k v m @?=
-                                second mapFromList (insertLookupWithKey f k v xs)
-
-                    prop "adjustMap" $ \(DuplPairs xs) k ->
-                        adjustMap succ k (mapFromListAs xs dummy)
-                            @?= mapFromList (adjustMap succ k xs)
-
-                    prop "adjustWithKey" $ \(DuplPairs xs) k ->
-                        adjustWithKey (+) k (mapFromListAs xs dummy)
-                            @?= mapFromList (adjustWithKey (+) k xs)
-
-                    prop "updateMap" $ \(DuplPairs xs) k ->
-                        let f i = if i < 0 then Nothing else Just $ i * 2
-                         in updateMap f k (mapFromListAs xs dummy)
-                                @?= mapFromList (updateMap f k xs)
-
-                    prop "updateWithKey" $ \(DuplPairs xs) k' ->
-                        let f k i = if i < 0 then Nothing else Just $ i * k
-                         in updateWithKey f k' (mapFromListAs xs dummy)
-                                @?= mapFromList (updateWithKey f k' xs)
-
-                    prop "updateLookupWithKey" $ \(DuplPairs xs) k' ->
-                        let f k i = if i < 0 then Nothing else Just $ i * k
-                         in updateLookupWithKey f k' (mapFromListAs xs dummy)
-                                @?= second mapFromList (updateLookupWithKey f k' xs)
-
-                    prop "alter" $ \(DuplPairs xs) k ->
-                        let m = mapFromListAs xs dummy
-                            f Nothing = Just (-1)
-                            f (Just i) = if i < 0 then Nothing else Just (i * 2)
-                         in lookup k (alterMap f k m) @?= f (lookup k m)
-
-                    prop "unionWith" $ \(DuplPairs xs) (DuplPairs ys) ->
-                        let m1 = unionWith (+)
-                                    (mapFromListAs xs dummy)
-                                    (mapFromListAs ys dummy)
-                            m2 = mapFromList (unionWith (+) xs ys)
-                         in m1 @?= m2
-
-                    prop "unionWithKey" $ \(DuplPairs xs) (DuplPairs ys) ->
-                        let f k x y = k + x + y
-                            m1 = unionWithKey f
-                                    (mapFromListAs xs dummy)
-                                    (mapFromListAs ys dummy)
-                            m2 = mapFromList (unionWithKey f xs ys)
-                         in m1 @?= m2
-
-                    prop "unionsWith" $ \(SmallList xss) ->
-                        let duplXss = map unDupl xss
-                            ms = map mapFromList duplXss `asTypeOf` [dummy]
-                         in unionsWith (+) ms
-                                @?= mapFromList (unionsWith (+) duplXss)
-
-                    prop "mapWithKey" $ \(DuplPairs xs) ->
-                        let m1 = mapWithKey (+) (mapFromList xs) `asTypeOf` dummy
-                            m2 = mapFromList $ mapWithKey (+) xs
-                         in m1 @?= m2
-
-                    prop "omapKeysWith" $ \(DuplPairs xs) ->
-                        let f = flip mod 5
-                            m1 = omapKeysWith (+) f (mapFromList xs) `asTypeOf` dummy
-                            m2 = mapFromList $ omapKeysWith (+) f xs
-                         in m1 @?= m2
-
-            test "Data.Map" (Map.empty :: Map.Map Int Int)
-                Map.lookup Map.insert Map.delete
-            test "Data.IntMap" (IntMap.empty :: IntMap.IntMap Int)
-                IntMap.lookup IntMap.insert IntMap.delete
-            test "Data.HashMap" (HashMap.empty :: HashMap.HashMap Int Int)
-                HashMap.lookup HashMap.insert HashMap.delete
-
-        describe "Foldl Integration" $ do
-            prop "vector" $ \xs -> do
+    describe "Foldl Integration" $ do
+        prop "vector" $ \xs -> do
 #if MIN_VERSION_foldl(1,3,0)
-                let x1 = Foldl.fold Foldl.vector (xs :: [Int])
-                    x2 = Foldl.purely ofoldlUnwrap Foldl.vector xs
+            let x1 = Foldl.fold Foldl.vector (xs :: [Int])
+                x2 = Foldl.purely ofoldlUnwrap Foldl.vector xs
 #else
-                x1 <- Foldl.foldM Foldl.vector (xs :: [Int])
-                x2 <- Foldl.impurely ofoldMUnwrap Foldl.vector xs
+            x1 <- Foldl.foldM Foldl.vector (xs :: [Int])
+            x2 <- Foldl.impurely ofoldMUnwrap Foldl.vector xs
 #endif
-                x2 @?= (x1 :: V.Vector Int)
-            prop "length" $ \xs -> do
-                let x1 = Foldl.fold Foldl.length (xs :: [Int])
-                    x2 = Foldl.purely ofoldlUnwrap Foldl.length xs
-                x2 @?= x1
+            x2 @?= (x1 :: V.Vector Int)
+        prop "length" $ \xs -> do
+            let x1 = Foldl.fold Foldl.length (xs :: [Int])
+                x2 = Foldl.purely ofoldlUnwrap Foldl.length xs
+            x2 @?= x1
 
-        describe "Replacing" $ do
-            let test typ dummy = describe typ $ do
-                    prop "replaceElem old new === omap (\\x -> if x == old then new else x)" $
-                        -- replace random element or any random value with random new value
-                        \x list new -> forAll (elements (x:list)) $ \old ->
-                        let seq' = fromListAs list dummy
-                        in replaceElem old new seq' @?= omap (\x' -> if x' == old then new else x') seq'
+    describe "Replacing" $ do
+        let test typ dummy = describe typ $ do
+                prop "replaceElem old new === omap (\\x -> if x == old then new else x)" $
+                    -- replace random element or any random value with random new value
+                    \x list new -> forAll (elements (x:list)) $ \old ->
+                    let seq' = fromListAs list dummy
+                    in replaceElem old new seq' @?= omap (\x' -> if x' == old then new else x') seq'
 #if MIN_VERSION_QuickCheck(2,8,0)
-                    prop "replaceSeq old new === ointercalate new . splitSeq old" $
-                        -- replace random subsequence with random new sequence
-                        \list new -> forAll (sublistOf list) $ \old ->
-                        let [seq', old', new'] = map (`fromListAs` dummy) [list, old, new]
-                        in replaceSeq old' new' seq' @?= ointercalate new' (splitSeq old' seq')
-                    prop "replaceSeq old old === id" $ \list -> forAll (sublistOf list) $ \old ->
-                        let [seq', old'] = map (`fromListAs` dummy) [list, old]
-                        in replaceSeq old' old' seq' @?= seq'
+                prop "replaceSeq old new === ointercalate new . splitSeq old" $
+                    -- replace random subsequence with random new sequence
+                    \list new -> forAll (sublistOf list) $ \old ->
+                    let [seq', old', new'] = map (`fromListAs` dummy) [list, old, new]
+                    in replaceSeq old' new' seq' @?= ointercalate new' (splitSeq old' seq')
+                prop "replaceSeq old old === id" $ \list -> forAll (sublistOf list) $ \old ->
+                    let [seq', old'] = map (`fromListAs` dummy) [list, old]
+                    in replaceSeq old' old' seq' @?= seq'
 #endif
-            test "List" ([] :: [Int])
-            test "Vector" (V.empty :: V.Vector Int)
-            test "Storable Vector" (VS.empty :: VS.Vector Int)
-            test "Unboxed Vector" (U.empty :: U.Vector Int)
+        test "List" ([] :: [Int])
+        test "Vector" (V.empty :: V.Vector Int)
+        test "Storable Vector" (VS.empty :: VS.Vector Int)
+        test "Unboxed Vector" (U.empty :: U.Vector Int)
 #if MIN_VERSION_vector(0,13,2)
-            test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
 #endif
-            test "Strict ByteString" S.empty
-            test "Lazy ByteString" L.empty
-            test "Strict Text" T.empty
-            test "Lazy Text" TL.empty
+        test "Strict ByteString" S.empty
+        test "Lazy ByteString" L.empty
+        test "Strict Text" T.empty
+        test "Lazy Text" TL.empty
 
-        describe "Sorting" $ do
-            let test typ dummy = describe typ $ do
-                    prop "sortBy" $ \input -> do
-                        let f x y = compare y x
-                        fromList (sortBy f input) @?= sortBy f (fromListAs input dummy)
-                    prop "sort" $ \input ->
-                        fromList (sort input) @?= sort (fromListAs input dummy)
-            test "List" ([] :: [Int])
-            test "Vector" (V.empty :: V.Vector Int)
-            test "Storable Vector" (VS.empty :: VS.Vector Int)
-            test "Unboxed Vector" (U.empty :: U.Vector Int)
+    describe "Sorting" $ do
+        let test typ dummy = describe typ $ do
+                prop "sortBy" $ \input -> do
+                    let f x y = compare y x
+                    fromList (sortBy f input) @?= sortBy f (fromListAs input dummy)
+                prop "sort" $ \input ->
+                    fromList (sort input) @?= sort (fromListAs input dummy)
+        test "List" ([] :: [Int])
+        test "Vector" (V.empty :: V.Vector Int)
+        test "Storable Vector" (VS.empty :: VS.Vector Int)
+        test "Unboxed Vector" (U.empty :: U.Vector Int)
 #if MIN_VERSION_vector(0,13,2)
-            test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
 #endif
-            test "Strict ByteString" S.empty
-            test "Lazy ByteString" L.empty
-            test "Strict Text" T.empty
-            test "Lazy Text" TL.empty
+        test "Strict ByteString" S.empty
+        test "Lazy ByteString" L.empty
+        test "Strict Text" T.empty
+        test "Lazy Text" TL.empty
 
-        describe "Intercalate" $ do
-            let test typ dummy = describe typ $ do
-                    prop "intercalate === defaultIntercalate" $ \list lists ->
-                        let seq' = fromListAs list dummy
-                            seqs = map (`fromListAs` dummy) lists
-                        in ointercalate seq' seqs @?= fromList (List.intercalate list lists)
-            test "List" ([] :: [Int])
-            test "Vector" (V.empty :: V.Vector Int)
-            test "Storable Vector" (VS.empty :: VS.Vector Int)
-            test "Unboxed Vector" (U.empty :: U.Vector Int)
+    describe "Intercalate" $ do
+        let test typ dummy = describe typ $ do
+                prop "intercalate === defaultIntercalate" $ \list lists ->
+                    let seq' = fromListAs list dummy
+                        seqs = map (`fromListAs` dummy) lists
+                    in ointercalate seq' seqs @?= fromList (List.intercalate list lists)
+        test "List" ([] :: [Int])
+        test "Vector" (V.empty :: V.Vector Int)
+        test "Storable Vector" (VS.empty :: VS.Vector Int)
+        test "Unboxed Vector" (U.empty :: U.Vector Int)
 #if MIN_VERSION_vector(0,13,2)
-            test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
 #endif
-            test "Strict ByteString" S.empty
-            test "Lazy ByteString" L.empty
-            test "Strict Text" T.empty
-            test "Lazy Text" TL.empty
+        test "Strict ByteString" S.empty
+        test "Lazy ByteString" L.empty
+        test "Strict Text" T.empty
+        test "Lazy Text" TL.empty
 
-        describe "Splitting" $ do
-            let test typ dummy = describe typ $ do
-                    let fromList' = (`fromListAs` dummy)
-                    let fromSepList sep = fromList' . map (fromMaybe sep)
-                    prop "intercalate sep . splitSeq sep === id" $
-                        \(fromList' -> sep) ->
-                        \(mconcat . map (maybe sep fromList') -> xs) ->
-                        ointercalate sep (splitSeq sep xs) @?= xs
-                    prop "splitSeq mempty xs === mempty : map singleton (otoList xs)" $
-                        \input ->
-                        splitSeq mempty (fromList' input) @?= mempty : map singleton input
-                    prop "splitSeq _ mempty == [mempty]" $
-                        \(fromList' -> sep) ->
-                        splitSeq sep mempty @?= [mempty]
-                    prop "intercalate (singleton sep) . splitElem sep === id" $
-                        \sep -> \(fromSepList sep -> xs) ->
-                        ointercalate (singleton sep) (splitElem sep xs) @?= xs
-                    prop "length . splitElem sep === succ . length . filter (== sep)" $
-                        \sep -> \(fromSepList sep -> xs) ->
-                        olength (splitElem sep xs) @?= olength (filter (== sep) xs) + 1
-                    prop "splitElem sep (replicate n sep) == replicate (n+1) mempty" $
-                        \(NonNegative n) sep ->
-                        splitElem sep (fromList' (replicate n sep)) @?= replicate (n + 1) mempty
-                    prop "splitElem sep === splitWhen (== sep)" $
-                        \sep -> \(fromSepList sep -> xs) ->
-                        splitElem sep xs @?= splitWhen (== sep) xs
-                    prop "splitElem sep === splitSeq (singleton sep)" $
-                        \sep -> \(fromSepList sep -> xs) ->
-                        splitElem sep xs @?= splitSeq (singleton sep) xs
-            test "List" ([] :: [Int])
-            test "Vector" (V.empty :: V.Vector Int)
-            test "Storable Vector" (VS.empty :: VS.Vector Int)
-            test "Unboxed Vector" (U.empty :: U.Vector Int)
+    describe "Splitting" $ do
+        let test typ dummy = describe typ $ do
+                let fromList' = (`fromListAs` dummy)
+                let fromSepList sep = fromList' . map (fromMaybe sep)
+                prop "intercalate sep . splitSeq sep === id" $
+                    \(fromList' -> sep) ->
+                    \(mconcat . map (maybe sep fromList') -> xs) ->
+                    ointercalate sep (splitSeq sep xs) @?= xs
+                prop "splitSeq mempty xs === mempty : map singleton (otoList xs)" $
+                    \input ->
+                    splitSeq mempty (fromList' input) @?= mempty : map singleton input
+                prop "splitSeq _ mempty == [mempty]" $
+                    \(fromList' -> sep) ->
+                    splitSeq sep mempty @?= [mempty]
+                prop "intercalate (singleton sep) . splitElem sep === id" $
+                    \sep -> \(fromSepList sep -> xs) ->
+                    ointercalate (singleton sep) (splitElem sep xs) @?= xs
+                prop "length . splitElem sep === succ . length . filter (== sep)" $
+                    \sep -> \(fromSepList sep -> xs) ->
+                    olength (splitElem sep xs) @?= olength (filter (== sep) xs) + 1
+                prop "splitElem sep (replicate n sep) == replicate (n+1) mempty" $
+                    \(NonNegative n) sep ->
+                    splitElem sep (fromList' (replicate n sep)) @?= replicate (n + 1) mempty
+                prop "splitElem sep === splitWhen (== sep)" $
+                    \sep -> \(fromSepList sep -> xs) ->
+                    splitElem sep xs @?= splitWhen (== sep) xs
+                prop "splitElem sep === splitSeq (singleton sep)" $
+                    \sep -> \(fromSepList sep -> xs) ->
+                    splitElem sep xs @?= splitSeq (singleton sep) xs
+        test "List" ([] :: [Int])
+        test "Vector" (V.empty :: V.Vector Int)
+        test "Storable Vector" (VS.empty :: VS.Vector Int)
+        test "Unboxed Vector" (U.empty :: U.Vector Int)
 #if MIN_VERSION_vector(0,13,2)
-            test "Strict Vector" (VSC.empty :: VSC.Vector Int)
+        test "Strict Vector" (VSC.empty :: VSC.Vector Int)
 #endif
-            test "Strict ByteString" S.empty
-            test "Lazy ByteString" L.empty
-            test "Strict Text" T.empty
-            test "Lazy Text" TL.empty
+        test "Strict ByteString" S.empty
+        test "Lazy ByteString" L.empty
+        test "Strict Text" T.empty
+        test "Lazy Text" TL.empty
 
-        describe "Other Issues" $ do
-            it "#26 headEx on a list works" $
-                headEx (1 : filter Prelude.odd [2,4..]) @?= (1 :: Int)
+    describe "Other Issues" $ do
+        it "#26 headEx on a list works" $
+            headEx (1 : filter Prelude.odd [2,4..]) @?= (1 :: Int)
 
-            it "#31 find doesn't infinitely loop on NonEmpty" $
-                find (== "a") ("a" NE.:| ["d","fgf"]) @?= Just ("a" :: String)
+        it "#31 find doesn't infinitely loop on NonEmpty" $
+            find (== "a") ("a" NE.:| ["d","fgf"]) @?= Just ("a" :: String)
 
-            it "#83 head on Seq works correctly" $ do
-                headEx (Seq.fromList [1 :: Int,2,3]) @?= (1 :: Int)
-                headMay (Seq.fromList [] :: Seq.Seq Int) @?= Nothing
+        it "#83 head on Seq works correctly" $ do
+            headEx (Seq.fromList [1 :: Int,2,3]) @?= (1 :: Int)
+            headMay (Seq.fromList [] :: Seq.Seq Int) @?= Nothing

--- a/mono-traversable/test/Main.hs
+++ b/mono-traversable/test/Main.hs
@@ -150,13 +150,14 @@ main = hspec $ do
             ocompareLength (replicate i () :: [()]) j @?= compare i j
 
     describe "groupBy" $ do
-        let test name dummy = prop name $ \xs -> do
+        let test name dummy = prop name $ \xs (Fn2 g) -> do
                 let seq' = fromListAs xs dummy
                 let listDef f = Prelude.fmap fromList . List.groupBy f . otoList
                 groupBy (==) seq' @?= listDef (==) seq'
                 groupBy (/=) seq' @?= listDef (/=) seq'
                 groupBy (<) seq' @?= listDef (<) seq'
                 groupBy (>) seq' @?= listDef (>) seq'
+                groupBy g seq' @?= listDef g seq'
         test "works on lists" ([] :: [Char])
         test "works on texts" ("" :: Text)
         test "works on strict bytestrings" S.empty

--- a/mono-traversable/test/Main.hs
+++ b/mono-traversable/test/Main.hs
@@ -150,7 +150,7 @@ main = hspec $ do
             ocompareLength (replicate i () :: [()]) j @?= compare i j
 
     describe "groupBy" $ do
-        let test name dummy = prop name $ \(QCM.NonEmpty xs) -> do
+        let test name dummy = prop name $ \xs -> do
                 let seq' = fromListAs xs dummy
                 let listDef f = Prelude.fmap fromList . List.groupBy f . otoList
                 groupBy (==) seq' @?= listDef (==) seq'


### PR DESCRIPTION
This addresses the lack of instances for `Data.Vector.Strict` that were added in `vector-0.13.2.0`.

Tests have been added for the new instances and have passed for the following stackage releases:

* `nightly-2024-11-18`
* `lts-22.42` (to confirm backwards compatibility)

@BebeSparkelSparkel 

@Bodigrim This should help resolve https://github.com/mgsloan/store/issues/179