### PR TITLE
Enabled native `groupBy` for vector

### DIFF
--- a/mono-traversable/ChangeLog.md
+++ b/mono-traversable/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for mono-traversable
 
+## 1.0.21.1
+
+* Enabled native `groupBy` for Vector, U.Vector, VS.Vector since they have been available since vector-0.13.0.0
+  [#251](https://github.com/snoyberg/mono-traversable/issues/251)
+
 ## 1.0.21.0
 
 * Support for vector 0.13.2.0, adding instances for [`Data.Vector.Strict`](https://hackage.haskell.org/package/vector-0.13.2.0/docs/Data-Vector-Strict.html) data structure.

--- a/mono-traversable/mono-traversable.cabal
+++ b/mono-traversable/mono-traversable.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           mono-traversable
-version:        1.0.21.0
+version:        1.0.21.1
 synopsis:       Type classes for mapping, folding, and traversing monomorphic containers
 description:    Please see the README at <https://www.stackage.org/package/mono-traversable>
 category:       Data

--- a/mono-traversable/package.yaml
+++ b/mono-traversable/package.yaml
@@ -1,5 +1,5 @@
 name:        mono-traversable
-version:     1.0.21.0
+version:     1.0.21.1
 synopsis:    Type classes for mapping, folding, and traversing monomorphic containers
 description: Please see the README at <https://www.stackage.org/package/mono-traversable>
 category:    Data

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -1067,7 +1067,11 @@ instance IsSequence (V.Vector a) where
     unsnoc v
         | V.null v = Nothing
         | otherwise = Just (V.init v, V.last v)
-    --groupBy = V.groupBy
+#if MIN_VERSION_vector(0,13,0)
+    -- | since 1.0.21.1
+    groupBy = V.groupBy
+    {-# INLINE groupBy #-}
+#endif
     tailEx = V.tail
     initEx = V.init
     unsafeTail = V.unsafeTail
@@ -1218,7 +1222,11 @@ instance U.Unbox a => IsSequence (U.Vector a) where
     unsnoc v
         | U.null v = Nothing
         | otherwise = Just (U.init v, U.last v)
-    --groupBy = U.groupBy
+#if MIN_VERSION_vector(0,13,0)
+    -- | since 1.0.21.1
+    groupBy = U.groupBy
+    {-# INLINE groupBy #-}
+#endif
     tailEx = U.tail
     initEx = U.init
     unsafeTail = U.unsafeTail
@@ -1291,7 +1299,11 @@ instance VS.Storable a => IsSequence (VS.Vector a) where
     unsnoc v
         | VS.null v = Nothing
         | otherwise = Just (VS.init v, VS.last v)
-    --groupBy = U.groupBy
+#if MIN_VERSION_vector(0,13,0)
+    -- | since 1.0.21.1
+    groupBy = VS.groupBy
+    {-# INLINE groupBy #-}
+#endif
     tailEx = VS.tail
     initEx = VS.init
     unsafeTail = VS.unsafeTail


### PR DESCRIPTION
groupBy been available since vector-0.13.0.0
closes #251