### PR TITLE
update for ghc-9.12 & silence various warnings

### DIFF
--- a/chunked-data/src/Data/Builder.hs
+++ b/chunked-data/src/Data/Builder.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleContexts #-}
 -- | Abstraction for different kinds of builders.
 --

--- a/chunked-data/src/Data/ChunkedZip.hs
+++ b/chunked-data/src/Data/ChunkedZip.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | Various zipping and unzipping functions for chunked data structures.
 module Data.ChunkedZip where
 
@@ -36,7 +37,11 @@ instance Zip [] where
 instance Zip NonEmpty where
     zipWith = NonEmpty.zipWith
     zip = NonEmpty.zip
+#if MIN_VERSION_base(4,19,0)
     unzip = Functor.unzip
+#else
+    unzip = NonEmpty.unzip
+#endif
 instance Zip Seq.Seq where
     zip = Seq.zip
     zipWith = Seq.zipWith

--- a/chunked-data/src/Data/ChunkedZip.hs
+++ b/chunked-data/src/Data/ChunkedZip.hs
@@ -3,6 +3,7 @@ module Data.ChunkedZip where
 
 import Prelude hiding (zipWith, zipWith3)
 import Control.Arrow ((&&&), (***))
+import qualified Data.Functor as Functor
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.List.NonEmpty (NonEmpty)
@@ -35,7 +36,7 @@ instance Zip [] where
 instance Zip NonEmpty where
     zipWith = NonEmpty.zipWith
     zip = NonEmpty.zip
-    unzip = NonEmpty.unzip
+    unzip = Functor.unzip
 instance Zip Seq.Seq where
     zip = Seq.zip
     zipWith = Seq.zipWith

--- a/chunked-data/src/Data/IOData.hs
+++ b/chunked-data/src/Data/IOData.hs
@@ -38,18 +38,18 @@ class IOData a where
 instance IOData ByteString.ByteString where
     readFile = liftIO . ByteString.readFile
     writeFile fp = liftIO . ByteString.writeFile fp
-    getLine = liftIO ByteString.getLine
+    getLine = liftIO ByteString8.getLine
     hGetContents = liftIO . ByteString.hGetContents
-    hGetLine = liftIO . ByteString.hGetLine
+    hGetLine = liftIO . ByteString8.hGetLine
     hPut h = liftIO . ByteString.hPut h
     hPutStrLn h = liftIO . ByteString8.hPutStrLn h
     hGetChunk = liftIO . flip ByteString.hGetSome defaultChunkSize
 instance IOData LByteString.ByteString where
     readFile = liftIO . LByteString.readFile
     writeFile fp = liftIO . LByteString.writeFile fp
-    getLine = liftM LByteString.fromStrict (liftIO ByteString.getLine)
+    getLine = liftM LByteString.fromStrict (liftIO ByteString8.getLine)
     hGetContents = liftIO . LByteString.hGetContents
-    hGetLine = liftM LByteString.fromStrict . liftIO . ByteString.hGetLine
+    hGetLine = liftM LByteString.fromStrict . liftIO . ByteString8.hGetLine
     hPut h = liftIO . LByteString.hPut h
     hPutStrLn h lbs = liftIO $ do
         LByteString.hPutStr h lbs

--- a/chunked-data/src/Data/IOData.hs
+++ b/chunked-data/src/Data/IOData.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP          #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 module Data.IOData where
 
 import           Control.Monad                 (liftM)
@@ -12,7 +13,7 @@ import qualified Data.Text                     as Text
 import qualified Data.Text.IO                  as Text
 import qualified Data.Text.Lazy                as LText
 import qualified Data.Text.Lazy.IO             as LText
-import           Prelude                       (Char, flip, ($), (.), FilePath)
+import           Prelude                       (type (~), Char, flip, ($), (.), FilePath)
 import qualified Prelude
 import           System.IO                     (Handle)
 import qualified System.IO

--- a/chunked-data/src/Data/IOData.hs
+++ b/chunked-data/src/Data/IOData.hs
@@ -13,7 +13,11 @@ import qualified Data.Text                     as Text
 import qualified Data.Text.IO                  as Text
 import qualified Data.Text.Lazy                as LText
 import qualified Data.Text.Lazy.IO             as LText
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
 import           Prelude                       (type (~), Char, flip, ($), (.), FilePath)
+#else
+import           Prelude                       (Char, flip, ($), (.), FilePath)
+#endif
 import qualified Prelude
 import           System.IO                     (Handle)
 import qualified System.IO

--- a/classy-prelude/src/ClassyPrelude.hs
+++ b/classy-prelude/src/ClassyPrelude.hs
@@ -153,8 +153,15 @@ module ClassyPrelude
     ) where
 
 import qualified Prelude
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
+import Prelude (type (~))
+#endif
 import Control.Applicative ((<**>),liftA,liftA2,liftA3,Alternative (..), optional)
+#if MIN_VERSION_base(4,19,0)
 import Data.Functor hiding (unzip)
+#else
+import Data.Functor
+#endif
 import Control.DeepSeq (deepseq, ($!!), force, NFData (..))
 import Control.Monad (when, unless, void, liftM, ap, forever, join, replicateM_, guard, MonadPlus (..), (=<<), (>=>), (<=<), liftM2, liftM3, liftM4, liftM5)
 import qualified Control.Concurrent.STM as STM
@@ -200,7 +207,9 @@ import Data.Time
     , getCurrentTime
     , defaultTimeLocale
     )
+#if MIN_VERSION_time(1,10,0)
 import qualified Data.Time as Time
+#endif
 
 import qualified Data.Set as Set
 import qualified Data.Map as Map
@@ -245,7 +254,7 @@ charToLower = Char.toLower
 charToUpper :: Char -> Char
 charToUpper = Char.toUpper
 
-readMay :: (Element c Prelude.~ Char, MonoFoldable c, Read a) => c -> Maybe a
+readMay :: (Element c ~ Char, MonoFoldable c, Read a) => c -> Maybe a
 readMay a = -- FIXME replace with safe-failure stuff
     case [x | (x, t) <- Prelude.reads (otoList a :: String), onull t] of
         [x] -> Just x

--- a/classy-prelude/src/ClassyPrelude.hs
+++ b/classy-prelude/src/ClassyPrelude.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 module ClassyPrelude
     ( -- * CorePrelude
       module CorePrelude

--- a/classy-prelude/src/ClassyPrelude.hs
+++ b/classy-prelude/src/ClassyPrelude.hs
@@ -155,7 +155,6 @@ module ClassyPrelude
 import qualified Prelude
 import Control.Applicative ((<**>),liftA,liftA2,liftA3,Alternative (..), optional)
 import Data.Functor hiding (unzip)
-import Control.Exception (assert)
 import Control.DeepSeq (deepseq, ($!!), force, NFData (..))
 import Control.Monad (when, unless, void, liftM, ap, forever, join, replicateM_, guard, MonadPlus (..), (=<<), (>=>), (<=<), liftM2, liftM3, liftM4, liftM5)
 import qualified Control.Concurrent.STM as STM
@@ -246,7 +245,7 @@ charToLower = Char.toLower
 charToUpper :: Char -> Char
 charToUpper = Char.toUpper
 
-readMay :: (Element c ~ Char, MonoFoldable c, Read a) => c -> Maybe a
+readMay :: (Element c Prelude.~ Char, MonoFoldable c, Read a) => c -> Maybe a
 readMay a = -- FIXME replace with safe-failure stuff
     case [x | (x, t) <- Prelude.reads (otoList a :: String), onull t] of
         [x] -> Just x

--- a/classy-prelude/test/main.hs
+++ b/classy-prelude/test/main.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/classy-prelude/test/main.hs
+++ b/classy-prelude/test/main.hs
@@ -12,7 +12,7 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import ClassyPrelude hiding (undefined)
 import Test.QuickCheck.Arbitrary
-import Prelude (undefined)
+import Prelude (type (~), undefined)
 import Control.Monad.Trans.Writer (tell, Writer, runWriter)
 import qualified Data.Set as Set
 import qualified Data.HashSet as HashSet
@@ -435,7 +435,7 @@ main = hspec $ do
             (otoList . fromByteVector . fromList $ ws) `shouldBe` ws
 
 data DummyException = DummyException
-    deriving (Show, Typeable)
+    deriving Show
 instance Exception DummyException
 
 instance Arbitrary (HashMap Int Char) where

--- a/classy-prelude/test/main.hs
+++ b/classy-prelude/test/main.hs
@@ -12,7 +12,11 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import ClassyPrelude hiding (undefined)
 import Test.QuickCheck.Arbitrary
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
 import Prelude (type (~), undefined)
+#else
+import Prelude (undefined)
+#endif
 import Control.Monad.Trans.Writer (tell, Writer, runWriter)
 import qualified Data.Set as Set
 import qualified Data.HashSet as HashSet

--- a/mono-traversable/src/Data/MonoTraversable.hs
+++ b/mono-traversable/src/Data/MonoTraversable.hs
@@ -47,7 +47,7 @@ import           Data.Word            (Word8)
 import Data.Int (Int, Int64)
 import           GHC.Exts             (build)
 import           GHC.Generics         ((:.:), (:*:), (:+:)(..), K1(..), M1(..), Par1(..), Rec1(..), U1(..), V1)
-import           Prelude              (Bool (..), const, Char, flip, IO, Maybe (..), Either (..),
+import           Prelude              (type (~), Bool (..), const, Char, flip, IO, Maybe (..), Either (..),
                                        (+), Integral, Ordering (..), compare, fromIntegral, Num, (>=),
                                        (==), seq, otherwise, Eq, Ord, (-), (*))
 import qualified Prelude

--- a/mono-traversable/src/Data/MonoTraversable.hs
+++ b/mono-traversable/src/Data/MonoTraversable.hs
@@ -47,9 +47,15 @@ import           Data.Word            (Word8)
 import Data.Int (Int, Int64)
 import           GHC.Exts             (build)
 import           GHC.Generics         ((:.:), (:*:), (:+:)(..), K1(..), M1(..), Par1(..), Rec1(..), U1(..), V1)
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
 import           Prelude              (type (~), Bool (..), const, Char, flip, IO, Maybe (..), Either (..),
                                        (+), Integral, Ordering (..), compare, fromIntegral, Num, (>=),
                                        (==), seq, otherwise, Eq, Ord, (-), (*))
+#else
+import           Prelude              (Bool (..), const, Char, flip, IO, Maybe (..), Either (..),
+                                       (+), Integral, Ordering (..), compare, fromIntegral, Num, (>=),
+                                       (==), seq, otherwise, Eq, Ord, (-), (*))
+#endif
 import qualified Prelude
 import qualified Data.ByteString.Internal as Unsafe
 import qualified Foreign.ForeignPtr.Unsafe as Unsafe

--- a/mono-traversable/src/Data/NonNull.hs
+++ b/mono-traversable/src/Data/NonNull.hs
@@ -51,7 +51,7 @@ import Data.MonoTraversable
 import Data.Sequences
 import Control.Monad.Trans.State.Strict (evalState, state)
 
-data NullError = NullError String deriving (Show, Typeable)
+data NullError = NullError String deriving Show
 instance Exception NullError
 
 -- | A monomorphic container that is not null.
@@ -59,7 +59,7 @@ newtype NonNull mono = NonNull
     { toNullable :: mono
     -- ^ __Safely__ convert from a non-null monomorphic container to a nullable monomorphic container.
     }
-    deriving (Eq, Ord, Read, Show, Data, Typeable)
+    deriving (Eq, Ord, Read, Show, Data)
 type instance Element (NonNull mono) = Element mono
 deriving instance MonoFunctor mono => MonoFunctor (NonNull mono)
 deriving instance MonoFoldable mono => MonoFoldable (NonNull mono)

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -17,7 +17,7 @@ import Data.Int (Int64, Int)
 import qualified Data.List as List
 import qualified Data.List.Split as List
 import qualified Control.Monad (filterM, replicateM)
-import Prelude (Bool (..), Monad (..), Maybe (..), Ordering (..), Ord (..), Eq (..), Functor (..), fromIntegral, otherwise, (-), fst, snd, Integral, ($), flip, maybe, error, (||))
+import Prelude (type (~), Bool (..), Monad (..), Maybe (..), Ordering (..), Ord (..), Eq (..), Functor (..), fromIntegral, otherwise, (-), fst, snd, Integral, ($), flip, maybe, error, (||))
 import Data.Char (Char, isSpace)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L

--- a/mono-traversable/src/Data/Sequences.hs
+++ b/mono-traversable/src/Data/Sequences.hs
@@ -17,7 +17,11 @@ import Data.Int (Int64, Int)
 import qualified Data.List as List
 import qualified Data.List.Split as List
 import qualified Control.Monad (filterM, replicateM)
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
 import Prelude (type (~), Bool (..), Monad (..), Maybe (..), Ordering (..), Ord (..), Eq (..), Functor (..), fromIntegral, otherwise, (-), fst, snd, Integral, ($), flip, maybe, error, (||))
+#else
+import Prelude (Bool (..), Monad (..), Maybe (..), Ordering (..), Ord (..), Eq (..), Functor (..), fromIntegral, otherwise, (-), fst, snd, Integral, ($), flip, maybe, error, (||))
+#endif
 import Data.Char (Char, isSpace)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L


### PR DESCRIPTION
It's basically all #ifdef work for library & compiler versions (for the instances where it's a language feature vs. a library API). 