### PR TITLE
ignore .ghc.environment.* and cabal.project.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 /dist/
 *.swp
+.ghc.environment.*
 .cabal-sandbox/
 cabal.sandbox.config
+cabal.project.local
 .stack-work/
 tarballs/
 *~


### PR DESCRIPTION
While theoretically possible to ignore much more, these were actually encountered.