### PR TITLE
mono-traversable/test: fix compilation with GHC 9.14

### DIFF
--- a/mono-traversable/test/Main.hs
+++ b/mono-traversable/test/Main.hs
@@ -357,7 +357,13 @@ main = hspec $ do
         test "List" ([5 :: Int])
 
     describe "Containers" $ do
-        let test typ dummy xlookup xinsert xdelete = describe typ $ do
+        let test :: (IsMap a, Eq a, Show a, MapValue a ~ Int, ContainerKey a ~ Int)
+                 => String -> a
+                 -> (ContainerKey a -> a -> Maybe (MapValue a)) -- ^ lookup
+                 -> (ContainerKey a -> MapValue a -> a -> a)    -- ^ insert
+                 -> (ContainerKey a -> a -> a)                  -- ^ delete
+                 -> Spec
+            test typ dummy xlookup xinsert xdelete = describe typ $ do
                 prop "difference" $ \(DuplPairs xs) (DuplPairs ys) ->
                     let m1 = mapFromList xs `difference` mapFromList ys
                         m2 = mapFromListAs (xs `difference` ys) dummy


### PR DESCRIPTION
Without this, the test suite fails to compile with GHC 9.14.1. For some reason, it infers a concrete type (e.g. Map Int Int) which then prevent the other two test statements (IntMap, HashMap Int Int) from compiling.